### PR TITLE
Removed conflicting dependency

### DIFF
--- a/services/build.gradle
+++ b/services/build.gradle
@@ -6,7 +6,9 @@ dependencies {
     compile addGroovy('groovy')
     compile addGroovy('groovy-json')
     compile addGroovy('groovy-xml')
-    compile group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
+    compile (group:'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1') {
+        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+    }
     compile group: 'net.sourceforge.nekohtml', name: 'nekohtml', version: '1.9.17'
     compile addSlf4J('slf4j-api')
     compile addSlf4J('log4j-over-slf4j')


### PR DESCRIPTION
 - Removed conflicting dependency of
   'org.apache.httpcomponents:httpclient'.
 - Downstream projects which enforce dependency convergence fail on
   this.