### PR TITLE
Fixed JSON to String mapping

### DIFF
--- a/ning-services/src/main/groovy/org/jfrog/artifactory/client/ning/ArtifactoryNingClientImpl.groovy
+++ b/ning-services/src/main/groovy/org/jfrog/artifactory/client/ning/ArtifactoryNingClientImpl.groovy
@@ -115,6 +115,11 @@ public class ArtifactoryNingClientImpl extends ArtifactoryImpl {
             try {
                 //This may puke on IOException, JsonParseException, JsonMappingException but we will let the caller deal with it.
                 if (responseType == ContentType.JSON && inputStream.available() > 0) {
+
+                    if (responseClass == String) {
+                        return (T) inputStream.text;
+                    }
+
                     return (T) objectMapper.readValue(inputStream, responseClass);
                 }
                 //TODO: Handle other cases.


### PR DESCRIPTION
 - The rest method is now able to return the JSON string.
 - The object mapper threw an exception when mapping the stream to a String object