### PR TITLE
Fixes for PluginsTests and RepositoryTests

### DIFF
--- a/services/src/test/java/org/jfrog/artifactory/client/PluginsTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/PluginsTests.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import static org.jfrog.artifactory.client.model.PluginType.executions;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
 
 /**
  * @author jbaruch
@@ -22,15 +23,22 @@ public class PluginsTests extends ArtifactoryTestsBase {
     @Test
     public void testPluginsList() {
         Map<PluginType, List<Plugin>> plugins = artifactory.plugins().list();
-        assertEquals(plugins.size(), 1);
         assertTrue(plugins.containsKey(executions));
         List<Plugin> executionPlugins = plugins.get(executions);
         verifyExecutionPlugins(executionPlugins);
     }
 
     private void verifyExecutionPlugins(List<Plugin> executionPlugins) {
-        assertEquals(executionPlugins.size(), 1);
-        Plugin helloWorldPlugin = executionPlugins.get(0);
+        Plugin helloWorldPlugin = null;
+
+        for(Plugin pl : executionPlugins) {
+            if (pl.getName().equals(PLUGIN_NAME)) {
+                helloWorldPlugin = pl;
+                break;
+            }
+        }
+
+        assertNotNull(helloWorldPlugin, PLUGIN_NAME+" Plugin not Found!");
         assertEquals("helloWorld", helloWorldPlugin.getName());
         Map<String, String> params = helloWorldPlugin.getParams();
         String httpMethod = helloWorldPlugin.getHttpMethod();

--- a/services/src/test/java/org/jfrog/artifactory/client/RepositoryTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/RepositoryTests.java
@@ -133,15 +133,15 @@ public class RepositoryTests extends ArtifactoryTestsBase {
         assertTrue(jcenter.isHandleReleases());
         assertFalse(jcenter.isHandleSnapshots());
         assertEquals(jcenter.getMaxUniqueSnapshots(), 0);
-        assertFalse(jcenter.isSuppressPomConsistencyChecks());
+        assertTrue(jcenter.isSuppressPomConsistencyChecks());
         assertFalse(jcenter.isHardFail());
         assertFalse(jcenter.isOffline());
         assertFalse(jcenter.isBlackedOut());
         assertTrue(jcenter.isStoreArtifactsLocally());
         assertEquals(jcenter.getSocketTimeoutMillis(), 15000);
         assertEquals(jcenter.getLocalAddress(), "");
-        assertEquals(jcenter.getRetrievalCachePeriodSecs(), 43200);
-        assertEquals(jcenter.getMissedRetrievalCachePeriodSecs(), 7200);
+        assertEquals(jcenter.getRetrievalCachePeriodSecs(), 600);
+        assertEquals(jcenter.getMissedRetrievalCachePeriodSecs(), 1800);
         assertEquals(jcenter.getUnusedArtifactsCleanupPeriodHours(), 0);
         assertFalse(jcenter.isFetchJarsEagerly());
         assertFalse(jcenter.isFetchSourcesEagerly());


### PR DESCRIPTION
Fixes for PluginsTest to remove tests that made assumption that the server will only have 1 plugin installed and provided better logic for finding and using helloWorld Plugin that doesn't depend on that being true. 

Fixed RepositoryTests getRemote to have checks based on the actual defaults loaded to a fresh artifactory installation.
