### PR TITLE
Implement GAVC search

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/Searches.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Searches.java
@@ -19,6 +19,20 @@ public interface Searches {
 
     Searches artifactsCreatedInDateRange(long fromMillis, long toMillis);
 
+    /**
+     * Search by maven coordinates.
+     * GroupId, artifactId, version and classifier, as well as repositories.
+     */
+    Searches artifactsByGavc();
+
+    Searches groupId(String groupId);
+
+    Searches artifactId(String artifactId);
+
+    Searches version(String version);
+
+    Searches classifier(String classifierId);
+
     List<RepoPath> doSearch();
 
     PropertyFilters itemsByProperty();

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/SearchesImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/SearchesImpl.groovy
@@ -51,6 +51,37 @@ class SearchesImpl implements Searches {
         this
     }
 
+    @Override
+    Searches artifactsByGavc() {
+        this.searchUrl = 'gavc'
+        this.searchQuery=[:]
+        this
+    }
+
+    @Override
+    Searches groupId(String groupId) {
+        this.searchQuery << [g:groupId]
+        this
+    }
+
+    @Override
+    Searches artifactId(String artifactId) {
+        this.searchQuery << [a:artifactId]
+        this
+    }
+
+    @Override
+    Searches version(String version) {
+        this.searchQuery << [v:version]
+        this
+    }
+
+    @Override
+    Searches classifier(String classifier) {
+        this.searchQuery << [c:classifier]
+        this
+    }
+
     List<RepoPath> doSearch() {
         if (!searchUrl) {
             throw new IllegalArgumentException("Search url wasn't set. Please call one of the 'artifacts...' methods before calling 'search()'")

--- a/services/src/test/java/org/jfrog/artifactory/client/DownloadUploadTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/DownloadUploadTests.java
@@ -153,6 +153,22 @@ public class DownloadUploadTests extends ArtifactoryTestsBase {
         assertEquals(deployed.getSize(), temp.length());
     }
 
+
+    @Test(groups = "uploadBasics", dependsOnGroups = "repositoryBasics")
+    public void testUploadWithMavenGAVC() throws IOException {
+        InputStream inputStream = this.getClass().getResourceAsStream("/sample.zip");
+        assertNotNull(inputStream);
+        final String targetPath = "com/example/com.example.test/1.0.0/com.example.test-1.0.0-zip.jar";
+        File deployed = artifactory.repository(NEW_LOCAL).upload(targetPath, inputStream).doUpload();
+        assertNotNull(deployed);
+        assertEquals(deployed.getRepo(), NEW_LOCAL);
+        assertEquals(deployed.getPath(), "/" + targetPath);
+        assertEquals(deployed.getCreatedBy(), username);
+        // GroupId: com.example; ArtifactId: com.example.test; Version 1.0.0; Classifier: zip
+        assertEquals(deployed.getDownloadUri(), url + "/" + NEW_LOCAL + "/" + targetPath);
+        assertEquals(deployed.getSize(), 442);
+    }
+
     @Test(groups = "uploadBasics", dependsOnMethods = "testUploadWithSingleProperty")
     public void testUploadExplodeArchive() throws IOException {
         artifactory.repository(NEW_LOCAL).upload("sample/sample.zip", this.getClass().getResourceAsStream("/sample.zip"))
@@ -171,7 +187,6 @@ public class DownloadUploadTests extends ArtifactoryTestsBase {
                 .withProperty("released", false).doUpload();
         assertTrue(curlAndStrip("api/storage/" + NEW_LOCAL + "/" + PATH + "?properties").contains("{\"build\":[\"28\"],\"colors\":[\"red\"],\"released\":[\"false\"]}"));
     }
-
 
     //TODO (jb) enable once RTFACT-5126 is fixed
     @Test(enabled = false, dependsOnMethods = "testUploadWithSingleProperty")
@@ -241,4 +256,5 @@ public class DownloadUploadTests extends ArtifactoryTestsBase {
                         .withProperty("foo", "bar").withMandatoryProperty("colors", "red").doDownload();
         assertEquals(textFrom(inputStream), textFrom(this.getClass().getResourceAsStream("/sample.txt")));
     }
+
 }

--- a/services/src/test/java/org/jfrog/artifactory/client/SearchTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/SearchTests.java
@@ -126,4 +126,27 @@ public class SearchTests extends ArtifactoryTestsBase {
         assertEquals(results.size(), 1);
         assertTrue(results.get(0).getItemPath().contains("a/b/c.txt"));
     }
+
+    @Test(dependsOnGroups = "uploadBasics")
+    public void testSearchByGavc() throws IOException {
+        List<RepoPath> results = artifactory.searches().artifactsByGavc()
+                .groupId("com.example")
+                .artifactId("com.example.test")
+                .version("1.0.0")
+                .classifier("zip")
+                .doSearch();
+        assertEquals(results.size(), 1);
+        assertTrue(results.get(0).getItemPath().contains("com.example.test-1.0.0-zip.jar"));
+    }
+
+    @Test(dependsOnGroups = "uploadBasics")
+    public void testSearchByGavcAndRepository() throws IOException {
+        List<RepoPath> results = artifactory.searches().artifactsByGavc()
+                .groupId("com.example")
+                .artifactId("com.example.test")
+                .repositories(NEW_LOCAL)
+                .doSearch();
+        assertEquals(results.size(), 1);
+        assertTrue(results.get(0).getItemPath().contains("com.example.test-1.0.0-zip.jar"));
+    }
 }


### PR DESCRIPTION
This is a pull request to resolve issue #52 

Compared to PR #53 I added unit tests to cover the new methods and named the search method `artifactsByGavc `to conform to the other methods, as well as the error message displayed by `doSearch`.