### PR TITLE
Bumped Groovy version to 2.3.11

### DIFF
--- a/services/build.gradle
+++ b/services/build.gradle
@@ -30,7 +30,7 @@ task createReleasePropertiesFile(type:Exec) {
 }
 
 def addGroovy(name) {
-    [group: 'org.codehaus.groovy', name: name, version: '2.3.2']
+    [group: 'org.codehaus.groovy', name: name, version: '2.3.11']
 }
 
 def addJackson(name) {


### PR DESCRIPTION
Hi,

Here's a small PR to fix an issue I had when using the `artifactory-client-java` API. The issue relates to this [ticket](https://support.jfrog.com/jFrogCasePage?id=500w000001d744q) open with JFrog and this StackOverflow [thread](http://stackoverflow.com/questions/25704985/groovy-httpbuilder-producing-error-when-parsing-valid-json).

In short, the `artifactory-client-java` API used to compile against Groovy 2.3.2 but this version of Groovy ships a buggy HTTPBuilder implementation which throws the following kind of errors (see below) 

```
groovy.json.JsonException: expecting '}' or ',' but got current char '' with an int value of 0

The current character read is '' with an int value of 0
expecting '}' or ',' but got current char '' with an int value of 0
line number 3
index number 255
 "created" : "2017-05-10T13:31:53.396Z"
..........................................................................................................................................................................^
 at groovy.json.internal.JsonParserCharArray.complain(JsonParserCharArray.java:163)
 at groovy.json.internal.JsonParserCharArray.decodeJsonObject(JsonParserCharArray.java:153)
 at groovy.json.internal.JsonParserCharArray.decodeValueInternal(JsonParserCharArray.java:197)
 at groovy.json.internal.JsonParserCharArray.decodeValue(JsonParserCharArray.java:167)
 at groovy.json.internal.JsonParserCharArray.decodeFromChars(JsonParserCharArray.java:46)
 at groovy.json.internal.JsonParserCharArray.parse(JsonParserCharArray.java:410)
 at groovy.json.internal.BaseJsonParser.parse(BaseJsonParser.java:121)
 at groovy.json.JsonSlurper.parse(JsonSlurper.java:224)
 at groovyx.net.http.ParserRegistry.parseJSON(ParserRegistry.java:280)
 at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
 at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```

The client code cannot apply the workaround described [here](http://stackoverflow.com/questions/25704985/groovy-httpbuilder-producing-error-when-parsing-valid-json) because the underlying HTTPBuilder instance isn't accessible (this is part of the implementation, not the public API).

The only way for me to fix this issue was to upgrade to a version of Groovy which ships a correct HTTPBuilder (in my case Groovy 2.3.11).

Updating the build to use this version of Groovy should ensure that end users don't stumble upon the same issue.