### PR TITLE
Make artifactory java client support concurrency 

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/RepositoryHandle.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/RepositoryHandle.java
@@ -35,5 +35,7 @@ public interface RepositoryHandle {
     Set<ItemPermission> effectivePermissions();
 
     boolean isFolder(String path);
+
+    boolean exists();
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-currentVersion=2.3.x-SNAPSHOT
+currentVersion=2.4.x-SNAPSHOT

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/RepositoryHandleImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/RepositoryHandleImpl.groovy
@@ -93,4 +93,8 @@ class RepositoryHandleImpl implements RepositoryHandle {
         return itemInfo.children != null;
     }
 
+    @Override
+    boolean exists() {
+        artifactory.head("${repository.getRepositoriesApi()}${repoKey}")
+    }
 }

--- a/services/src/main/resources/artifactory.client.release.properties
+++ b/services/src/main/resources/artifactory.client.release.properties
@@ -1,1 +1,1 @@
-version=2.3.5
+version=2.4.x-SNAPSHOT

--- a/services/src/test/groovy/org/jfrog/artifactory/client/AsyncTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/AsyncTests.groovy
@@ -12,6 +12,7 @@ import org.testng.annotations.Test
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 /**
  * test that client supports Async rest calls
@@ -23,7 +24,6 @@ public class AsyncTests {
 
     @Test
     public void testChecksumDeployAsync() {
-        init()
         def repoName = 'testrepo'
         createRepo(repoName)
         def stream = this.class.getResourceAsStream("/sample.zip")
@@ -33,7 +33,7 @@ public class AsyncTests {
         for (int i = 0; i < 1000; i++) {
             futures.add(executor.submit(new ArtifactUploadRunnable(sha1, i)))
         }
-        sleep(3000)
+        executor.awaitTermination(3000, TimeUnit.MILLISECONDS)
         def exceptions = futures.collect { it.get() }.findAll { it != null }
         Assert.assertEquals(exceptions.empty, true)
         artifactory.repository(repoName).delete()
@@ -41,7 +41,6 @@ public class AsyncTests {
 
     @Test
     public void testUploadAsync() {
-        init()
         def repoName = 'testrepo'
         createRepo(repoName)
         def stream = this.class.getResourceAsStream("/sample.zip")
@@ -51,7 +50,7 @@ public class AsyncTests {
         for (int i = 0; i < 1000; i++) {
             futures.add(executor.submit(new ArtifactUploadRunnable(i)))
         }
-        sleep(3000)
+        executor.awaitTermination(3000, TimeUnit.MILLISECONDS)
         def exceptions = futures.collect { it.get() }.findAll { it != null }
         Assert.assertEquals(exceptions.empty, true)
         artifactory.repository(repoName).delete()

--- a/services/src/test/groovy/org/jfrog/artifactory/client/AsyncTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/AsyncTests.groovy
@@ -1,0 +1,128 @@
+package org.jfrog.artifactory.client
+
+import org.apache.commons.codec.digest.DigestUtils
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+import org.jfrog.artifactory.client.model.Repository
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
+import org.jfrog.artifactory.client.model.repository.settings.impl.GenericRepositorySettingsImpl
+import org.testng.Assert
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+ * test that client supports Async rest calls
+ *
+ * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
+ */
+public class AsyncTests {
+    Artifactory artifactory
+
+    @Test
+    public void testChecksumDeployAsync() {
+        init()
+        def repoName = 'testrepo'
+        createRepo(repoName)
+        def stream = this.class.getResourceAsStream("/sample.zip")
+        def sha1 = DigestUtils.sha1(stream.bytes).encodeHex().toString()
+        def futures = []
+        ExecutorService executor = Executors.newFixedThreadPool(30)
+        for (int i = 0; i < 1000; i++) {
+            futures.add(executor.submit(new ArtifactUploadRunnable(sha1, i)))
+        }
+        sleep(3000)
+        def exceptions = futures.collect { it.get() }.findAll { it != null }
+        Assert.assertEquals(exceptions.empty, true)
+        artifactory.repository(repoName).delete()
+    }
+
+    @Test
+    public void testUploadAsync() {
+        init()
+        def repoName = 'testrepo'
+        createRepo(repoName)
+        def stream = this.class.getResourceAsStream("/sample.zip")
+        def sha1 = DigestUtils.sha1(stream.bytes).encodeHex().toString()
+        def futures = []
+        ExecutorService executor = Executors.newFixedThreadPool(30)
+        for (int i = 0; i < 1000; i++) {
+            futures.add(executor.submit(new ArtifactUploadRunnable(i)))
+        }
+        sleep(3000)
+        def exceptions = futures.collect { it.get() }.findAll { it != null }
+        Assert.assertEquals(exceptions.empty, true)
+        artifactory.repository(repoName).delete()
+    }
+
+    @BeforeMethod
+    void init() {
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager()
+        connectionManager.setDefaultMaxPerRoute(20)
+        connectionManager.setMaxTotal(20)
+
+        ArtifactoryClientBuilder artifactoryClientBuilder = ArtifactoryClientBuilder.create()
+        artifactoryClientBuilder
+                .setUrl("http://ci1:7071/artifactory")
+                .setConnectionManager(connectionManager)
+
+                .setUsername('admin')
+                .setPassword('password')
+
+        artifactory = artifactoryClientBuilder.build()
+
+    }
+
+    public class ArtifactUploadRunnable implements Callable<Exception> {
+        InputStream stream
+        String sha1
+        int i
+
+        ArtifactUploadRunnable(int i) {
+            //just upload
+            this.i = i
+        }
+
+        ArtifactUploadRunnable(String sha1, int i) {
+            //checksum upload
+            this.sha1 = sha1
+            this.i = i
+        }
+
+        @Override
+        Exception call() throws Exception {
+            try {
+                stream = this.class.getResourceAsStream("/sample.zip")
+                def targetPath = 'a/b' + i
+                UploadableArtifact uploadableArtifact = artifactory.repository("testrepo")
+                        .upload(targetPath, stream)
+                        .withProperty("propA", 'x')
+                        .withProperty("propB", 'y')
+
+
+                uploadableArtifact.bySha1Checksum(sha1)
+
+                uploadableArtifact.doUpload()
+                return null
+            } catch (Exception e) {
+                return e
+            }
+        }
+    }
+
+    def createRepo(String name) {
+        RepositorySettings genericRepo = new GenericRepositorySettingsImpl();
+
+        Repository repository = artifactory.repositories().builders().localRepositoryBuilder()
+                .key(name)
+                .repositorySettings(genericRepo)
+                .build()
+        artifactory.repositories().create(0, repository)
+    }
+}
+
+
+
+

--- a/services/src/test/java/org/jfrog/artifactory/client/RepositoryTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/RepositoryTests.java
@@ -1,7 +1,6 @@
 package org.jfrog.artifactory.client;
 
 import org.jfrog.artifactory.client.model.*;
-import org.jfrog.artifactory.client.model.impl.ContentSyncImpl;
 import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings;
 import org.jfrog.artifactory.client.model.repository.settings.impl.GenericRepositorySettingsImpl;
 import org.testng.annotations.BeforeMethod;
@@ -29,10 +28,10 @@ public class RepositoryTests extends ArtifactoryTestsBase {
         RepositorySettings genericRepo = new GenericRepositorySettingsImpl();
 
         localRepository = artifactory.repositories().builders().localRepositoryBuilder()
-            .key(NEW_LOCAL)
-            .description("new local repository")
-            .repositorySettings(genericRepo)
-            .build();
+                .key(NEW_LOCAL)
+                .description("new local repository")
+                .repositorySettings(genericRepo)
+                .build();
     }
 
     @Test(groups = "repositoryBasics", dependsOnMethods = "testDelete")
@@ -89,7 +88,7 @@ public class RepositoryTests extends ArtifactoryTestsBase {
     @Test(groups = "repositoryBasics")
     public void testDelete() throws Exception {
         //all the assertions are taken care of in deleteRepoIfExists
-            deleteRepoIfExists(NEW_LOCAL);
+        deleteRepoIfExists(NEW_LOCAL);
     }
 
     @Test
@@ -201,5 +200,13 @@ public class RepositoryTests extends ArtifactoryTestsBase {
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Internal Server Error"));
         }
+    }
+
+    @Test(dependsOnMethods = "testCreate")
+    public void testRepositoryExists() throws IOException {
+
+        assertTrue(artifactory.repository(NEW_LOCAL).exists());
+        String notExistsRepoName = Long.toString(System.currentTimeMillis());
+        assertFalse(artifactory.repository(notExistsRepoName).exists());
     }
 }

--- a/services/src/test/java/org/jfrog/artifactory/client/RestCallTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/RestCallTests.java
@@ -121,7 +121,7 @@ public class RestCallTests extends ArtifactoryTestsBase {
 
     @Test
     public void testGetPermissionTargets() {
-        ArrayList response = getPermissionTargets();
+        List response = getPermissionTargets();
         assertNotNull(response);
     }
 
@@ -139,7 +139,7 @@ public class RestCallTests extends ArtifactoryTestsBase {
         artifactory.restCall(req);
 
         // Verify permission target created:
-        ArrayList permissions = getPermissionTargets();
+        List permissions = getPermissionTargets();
         assertTrue(findPermissionInLiat(permissions, permissionName));
 
         // Delete permission target:
@@ -164,7 +164,7 @@ public class RestCallTests extends ArtifactoryTestsBase {
         return artifactory.restCall(deleteBuild);
     }
 
-    private ArrayList getPermissionTargets() {
+    private List getPermissionTargets() {
         ArtifactoryRequest req = new ArtifactoryRequestImpl()
                 .method(ArtifactoryRequest.Method.GET)
                 .apiUrl("api/security/permissions")
@@ -193,7 +193,7 @@ public class RestCallTests extends ArtifactoryTestsBase {
         return new ObjectMapper().readValue(json, Map.class);
     }
 
-    private boolean findPermissionInLiat(ArrayList list, String permissionName) {
+    private boolean findPermissionInLiat(List list, String permissionName) {
         for(Object permission : list) {
             Object name = ((Map)permission).get("name");
             if (permissionName.equals(name)) {


### PR DESCRIPTION
Make artifactory java client support concurrency 
we need the artifactory java client to support concurrent requests.

the old rest method (wrapper) would replace the underlying httpClient's
parser on runtime according to the content type and the expected response class,
this operation was not thread safe and did not meet the performance requirements that we need.
the wrapper was removed and parsing is now done explicitly by us and the HttpClient's parser is not replaced at runtime.
this makes the artifactory client thread safe in regards to rest requests.