### PR TITLE
Add ability to configure replications for local and remote repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,67 @@ String result = artifactory.repositories().update(updatedRepository);
 String result = artifactory.repository("RepoName").delete();
 ```
 
+##### Listing all Repository Replications
+```
+// Method supported for local and remote repositories
+List<Replication> replications = artifactory.repository("RepoName").replications.list()
+```
+
+##### Deleting all Repository Replications
+```
+// Method supported for local and remote repositories
+artifactory.repository("RepoName").replications.delete()
+```
+
+##### Creating / Updating a Local Repository's Replication(s)
+```
+def replication1 = new LocalReplicationImpl()
+replication1.url = "http://hostname1:port/artifactory/RepoName"
+replication1.socketTimeoutMillis = 30000
+replication1.username = 'john.doe'
+replication1.password = 'secret'
+replication1.enableEventReplication = false
+replication1.enabled = false
+replication1.cronExp = '0 0 0/2 * * ?'
+replication1.syncDeletes = true
+replication1.syncProperties = true
+replication1.syncStatistics = true
+replication1.repoKey = "RepoName"
+
+def replication2 = new LocalReplicationImpl()
+replication2.url = "http://hostname2:port/artifactory/RepoName"
+replication2.socketTimeoutMillis = 60000
+replication2.username = 'jane.doe'
+replication2.password = 'secret2'
+replication2.enableEventReplication = true
+replication2.enabled = true
+replication2.cronExp = '0 0 0/4 * * ?'
+replication2.syncDeletes = true
+replication2.syncProperties = true
+replication2.syncStatistics = true
+replication2.repoKey = "RepoName"
+
+// Create (or replace) one replication
+artifactory.repository("RepoName").replications.createOrReplace(replication1)
+artifactory.repository("RepoName").replications.createOrReplace([ replication1 ])
+
+// Create (or replace) several replications at once
+artifactory.repository("RepoName").replications.createOrReplace([ replication1, replication2 ])
+```
+
+##### Creating / Updating a Remote Repository's Replication
+```
+def replication = new RemoteReplicationImpl()
+replication.enabled = false
+replication.cronExp = '0 0 0/2 * * ?'
+replication.syncDeletes = true
+replication.syncProperties = true
+replication.repoKey = "RepoName"
+
+// Create (or replace) one replication
+artifactory.repository("RepoName").replications.createOrReplace(replication)
+```
+
 ##### Managing Xray properties
 ```
     Repository repository = artifactory.repository("RepoName").get();

--- a/api/src/main/java/org/jfrog/artifactory/client/Replications.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Replications.java
@@ -1,0 +1,12 @@
+package org.jfrog.artifactory.client;
+
+import org.jfrog.artifactory.client.model.Replication;
+
+import java.util.List;
+
+public interface Replications {
+
+    List<Replication> list();
+
+    String getReplicationsApi();
+}

--- a/api/src/main/java/org/jfrog/artifactory/client/Replications.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Replications.java
@@ -12,10 +12,10 @@ public interface Replications {
     List<Replication> list();
 
     // Supports local and remote repositories
-    void createOrReplaceReplication(Replication replication);
+    void createOrReplace(Replication replication);
 
     // Supports only local repositories
-    void createOrReplaceReplications(Collection<LocalReplication> replications);
+    void createOrReplace(Collection<LocalReplication> replications);
 
     void delete();
 

--- a/api/src/main/java/org/jfrog/artifactory/client/Replications.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Replications.java
@@ -1,5 +1,6 @@
 package org.jfrog.artifactory.client;
 
+import org.jfrog.artifactory.client.model.LocalReplication;
 import org.jfrog.artifactory.client.model.Replication;
 
 import java.util.List;
@@ -7,6 +8,8 @@ import java.util.List;
 public interface Replications {
 
     List<Replication> list();
+
+    void createOrReplaceReplication(LocalReplication replication);
 
     void delete();
 

--- a/api/src/main/java/org/jfrog/artifactory/client/Replications.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Replications.java
@@ -1,16 +1,25 @@
 package org.jfrog.artifactory.client;
 
+import org.jfrog.artifactory.client.model.LocalReplication;
 import org.jfrog.artifactory.client.model.Replication;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface Replications {
 
+    // Supports local and remote repositories
     List<Replication> list();
 
+    // Supports local and remote repositories
     void createOrReplaceReplication(Replication replication);
+
+    // Supports only local repositories
+    void createOrReplaceReplications(Collection<LocalReplication> replications);
 
     void delete();
 
     String getReplicationsApi();
+
+    String getReplicationsMultipleApi();
 }

--- a/api/src/main/java/org/jfrog/artifactory/client/Replications.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Replications.java
@@ -8,5 +8,7 @@ public interface Replications {
 
     List<Replication> list();
 
+    void delete();
+
     String getReplicationsApi();
 }

--- a/api/src/main/java/org/jfrog/artifactory/client/Replications.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Replications.java
@@ -1,6 +1,5 @@
 package org.jfrog.artifactory.client;
 
-import org.jfrog.artifactory.client.model.LocalReplication;
 import org.jfrog.artifactory.client.model.Replication;
 
 import java.util.List;
@@ -9,7 +8,7 @@ public interface Replications {
 
     List<Replication> list();
 
-    void createOrReplaceReplication(LocalReplication replication);
+    void createOrReplaceReplication(Replication replication);
 
     void delete();
 

--- a/api/src/main/java/org/jfrog/artifactory/client/RepositoryHandle.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/RepositoryHandle.java
@@ -36,6 +36,8 @@ public interface RepositoryHandle {
 
     Set<ItemPermission> effectivePermissions();
 
+    Replications getReplications();
+
     boolean isFolder(String path);
 
     boolean exists();

--- a/api/src/main/java/org/jfrog/artifactory/client/model/LocalReplication.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/LocalReplication.java
@@ -1,0 +1,14 @@
+package org.jfrog.artifactory.client.model;
+
+public interface LocalReplication extends Replication {
+
+    String getUrl();
+
+    long getSocketTimeoutMillis();
+
+    String getUsername();
+
+    String getPassword();
+
+    boolean isEnableEventReplication();
+}

--- a/api/src/main/java/org/jfrog/artifactory/client/model/LocalReplication.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/LocalReplication.java
@@ -11,4 +11,6 @@ public interface LocalReplication extends Replication {
     String getPassword();
 
     boolean isEnableEventReplication();
+
+    boolean isSyncStatistics();
 }

--- a/api/src/main/java/org/jfrog/artifactory/client/model/RemoteReplication.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/RemoteReplication.java
@@ -1,0 +1,5 @@
+package org.jfrog.artifactory.client.model;
+
+public interface RemoteReplication extends Replication {
+
+}

--- a/api/src/main/java/org/jfrog/artifactory/client/model/Replication.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/Replication.java
@@ -1,0 +1,14 @@
+package org.jfrog.artifactory.client.model;
+
+public interface Replication {
+
+    boolean isEnabled();
+
+    String getCronExp();
+
+    boolean isSyncDeletes();
+
+    boolean isSyncProperties();
+
+    String getRepoKey();
+}

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
@@ -69,7 +69,7 @@ class ReplicationsImpl implements Replications {
     }
 
     @Override
-    void createOrReplaceReplication(LocalReplication replication) {
+    void createOrReplaceReplication(Replication replication) {
         artifactory.put("${getReplicationsApi()}${repoKey}", [:], ContentType.ANY, null, ContentType.JSON, replication)
     }
 

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
@@ -68,6 +68,24 @@ class ReplicationsImpl implements Replications {
     }
 
     @Override
+    void delete() {
+        // Determine the type of the repository (not all repository types support replications)
+        def repository = artifactory.repository(repoKey).get()
+
+        if (!repository) {
+            throw new RuntimeException("The repository '${repoKey}' doesn't exist")
+        }
+
+        def path = "${getReplicationsApi()}${repoKey}"
+
+        if ((repository.rclass == RepositoryTypeImpl.LOCAL) || (repository.rclass == RepositoryTypeImpl.REMOTE)) {
+            artifactory.delete(path, [:], ContentType.JSON)
+        } else {
+            throw new UnsupportedOperationException("The method isn't supported for a ${repository.rclass} repository")
+        }
+    }
+
+    @Override
     String getReplicationsApi() {
         return baseApiPath + "/replications/";
     }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.impl
 import groovyx.net.http.ContentType
 import groovyx.net.http.HttpResponseException
 import org.jfrog.artifactory.client.Replications
+import org.jfrog.artifactory.client.model.LocalReplication
 import org.jfrog.artifactory.client.model.Replication
 import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
 import org.jfrog.artifactory.client.model.impl.RemoteReplicationImpl
@@ -65,6 +66,11 @@ class ReplicationsImpl implements Replications {
         } else {
             throw new UnsupportedOperationException("The method isn't supported for a ${repository.rclass} repository")
         }
+    }
+
+    @Override
+    void createOrReplaceReplication(LocalReplication replication) {
+        artifactory.put("${getReplicationsApi()}${repoKey}", [:], ContentType.ANY, null, ContentType.JSON, replication)
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
@@ -44,9 +44,11 @@ class ReplicationsImpl implements Replications {
             def json = artifactory.get(path, [:], ContentType.JSON)
 
             if (repository.rclass == RepositoryTypeImpl.LOCAL) {
+                // For a local repository, the REST service always returns an array of JSON objects
                 return json.collect { new LocalReplicationImpl(it) }
             } else if (repository.rclass == RepositoryTypeImpl.REMOTE) {
-                return json.collect { new RemoteReplicationImpl(it) }
+                // For a remote repository, the REST service returns a JSON object (not an array)
+                return [ new RemoteReplicationImpl(json) ]
             }
         } catch (HttpResponseException e) {
             if (e.statusCode == 404) {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
@@ -72,12 +72,12 @@ class ReplicationsImpl implements Replications {
     }
 
     @Override
-    void createOrReplaceReplication(Replication replication) {
+    void createOrReplace(Replication replication) {
         artifactory.put("${getReplicationsApi()}${repoKey}", [:], ContentType.ANY, null, ContentType.JSON, replication)
     }
 
     @Override
-    void createOrReplaceReplications(Collection<LocalReplication> replications) {
+    void createOrReplace(Collection<LocalReplication> replications) {
         assert replications
 
         // Determine the type of the repository (not all repository types support replications)

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
@@ -39,7 +39,8 @@ class ReplicationsImpl implements Replications {
         if ((repository.rclass == RepositoryTypeImpl.LOCAL) || (repository.rclass == RepositoryTypeImpl.REMOTE)) {
             try {
                 // We can't use Jackson to convert the JSON into java objects because the structure of the JSON response
-                // changes depending on the number of replications returned by the server
+                // changes depending on the number of replications returned by the server. This changed in version 4.15
+                // (see the release notes) but is still required to properly process the response from old versions
                 // One replication -> The API returns a JSON object
                 // Two replications -> The API returns an array of JSON objects
                 def json = artifactory.get(path, [:], ContentType.JSON)
@@ -104,7 +105,7 @@ class ReplicationsImpl implements Replications {
             object.put('enabled', replication.enabled)
             object.put('syncDeletes', replication.syncDeletes)
             object.put('syncProperties', replication.syncProperties)
-            // TODO object.put('syncStatistics', replication.syncStatistics)
+            object.put('syncStatistics', replication.syncStatistics)
             object.put('repoKey', replication.repoKey)
 
             array.add(object)

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
@@ -1,0 +1,74 @@
+package org.jfrog.artifactory.client.impl
+
+import groovyx.net.http.ContentType
+import groovyx.net.http.HttpResponseException
+import org.jfrog.artifactory.client.Replications
+import org.jfrog.artifactory.client.model.Replication
+import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
+import org.jfrog.artifactory.client.model.impl.RemoteReplicationImpl
+import org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl
+
+class ReplicationsImpl implements Replications {
+
+    private String baseApiPath
+
+    private ArtifactoryImpl artifactory
+
+    private String repoKey
+
+    ReplicationsImpl(ArtifactoryImpl artifactory, String baseApiPath, String repoKey) {
+        this.artifactory = artifactory
+        this.baseApiPath = baseApiPath
+        this.repoKey = repoKey
+    }
+
+    @Override
+    List<Replication> list() {
+        // Determine the type of the repository (not all repository types support replications)
+        def repository = artifactory.repository(repoKey).get()
+
+        if (!repository) {
+            throw new RuntimeException("The repository '${repoKey}' doesn't exist")
+        }
+
+        def path = "${getReplicationsApi()}${repoKey}"
+
+        if ((repository.rclass == RepositoryTypeImpl.LOCAL) || (repository.rclass == RepositoryTypeImpl.REMOTE)) {
+            try {
+                // We can't use Jackson to convert the JSON into java objects because the structure of the JSON response
+                // changes depending on the number of replications returned by the server
+                // One replication -> The API returns a JSON object
+                // Two replications -> The API returns an array of JSON objects
+                def json = artifactory.get(path, [:], ContentType.JSON)
+
+                if (repository.rclass == RepositoryTypeImpl.LOCAL) {
+                    if (json instanceof List) {
+                        return json.collect { new LocalReplicationImpl(it) }
+                    } else {
+                        return [ new LocalReplicationImpl(json) ]
+                    }
+                } else if (repository.rclass == RepositoryTypeImpl.REMOTE) {
+                    if (json instanceof List) {
+                        return json.collect { new RemoteReplicationImpl(it) }
+                    } else {
+                        return [ new RemoteReplicationImpl(json) ]
+                    }
+                }
+            } catch (HttpResponseException e) {
+                if (e.statusCode == 404) {
+                    // The REST API returns a 404 status code when the repository defines no replication
+                    return []
+                }
+
+                throw e
+            }
+        } else {
+            throw new UnsupportedOperationException("The method isn't supported for a ${repository.rclass} repository")
+        }
+    }
+
+    @Override
+    String getReplicationsApi() {
+        return baseApiPath + "/replications/";
+    }
+}

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ReplicationsImpl.groovy
@@ -89,6 +89,9 @@ class ReplicationsImpl implements Replications {
 
         def path = "${getReplicationsMultipleApi()}${repoKey}"
 
+        // The code below adapts a 'Get Repository Replication Configuration' service response into a
+        // 'Create or Replace Local Multi-push Replication' service request
+
         // Use the first replication to infer the shared properties
         def first = replications.iterator().next() as LocalReplication
 

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/RepositoryHandleImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/RepositoryHandleImpl.groovy
@@ -111,4 +111,9 @@ class RepositoryHandleImpl implements RepositoryHandle {
     boolean exists() {
         artifactory.head("${repository.getRepositoriesApi()}${repoKey}")
     }
+
+    @Override
+    Replications getReplications() {
+        return new ReplicationsImpl(artifactory, baseApiPath, repoKey)
+    }
 }

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalReplicationImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalReplicationImpl.java
@@ -1,0 +1,138 @@
+package org.jfrog.artifactory.client.model.impl;
+
+import org.jfrog.artifactory.client.model.LocalReplication;
+
+public class LocalReplicationImpl implements LocalReplication {
+
+    private String url;
+    private long socketTimeoutMillis;
+    private String username;
+    private String password;
+    private boolean enableEventReplication;
+    private boolean enabled;
+    private String cronExp;
+    private boolean syncDeletes;
+    private boolean syncProperties;
+    private String repoKey;
+
+    LocalReplicationImpl() {
+    }
+
+    LocalReplicationImpl(String url, long socketTimeoutMillis, String username, String password,
+        boolean enableEventReplication, boolean enabled, String cronExp, boolean syncDeletes, boolean syncProperties,
+        String repoKey) {
+
+        this.url = url;
+        this.socketTimeoutMillis = socketTimeoutMillis;
+        this.username = username;
+        this.password = password;
+        this.enableEventReplication = enableEventReplication;
+        this.enabled = enabled;
+        this.cronExp = cronExp;
+        this.syncDeletes = syncDeletes;
+        this.syncProperties = syncProperties;
+        this.repoKey = repoKey;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public long getSocketTimeoutMillis() {
+        return socketTimeoutMillis;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isEnableEventReplication() {
+        return enableEventReplication;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public String getCronExp() {
+        return cronExp;
+    }
+
+    @Override
+    public boolean isSyncDeletes() {
+        return syncDeletes;
+    }
+
+    @Override
+    public boolean isSyncProperties() {
+        return syncProperties;
+    }
+
+    @Override
+    public String getRepoKey() {
+        return repoKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        LocalReplicationImpl that = (LocalReplicationImpl) o;
+
+        if (socketTimeoutMillis != that.socketTimeoutMillis) return false;
+        if (enableEventReplication != that.enableEventReplication) return false;
+        if (enabled != that.enabled) return false;
+        if (syncDeletes != that.syncDeletes) return false;
+        if (syncProperties != that.syncProperties) return false;
+        if (url != null ? !url.equals(that.url) : that.url != null) return false;
+        if (username != null ? !username.equals(that.username) : that.username != null) return false;
+        if (password != null ? !password.equals(that.password) : that.password != null) return false;
+        if (cronExp != null ? !cronExp.equals(that.cronExp) : that.cronExp != null) return false;
+
+        return repoKey != null ? repoKey.equals(that.repoKey) : that.repoKey == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = url != null ? url.hashCode() : 0;
+        result = 31 * result + (int) (socketTimeoutMillis ^ (socketTimeoutMillis >>> 32));
+        result = 31 * result + (username != null ? username.hashCode() : 0);
+        result = 31 * result + (password != null ? password.hashCode() : 0);
+        result = 31 * result + (enableEventReplication ? 1 : 0);
+        result = 31 * result + (enabled ? 1 : 0);
+        result = 31 * result + (cronExp != null ? cronExp.hashCode() : 0);
+        result = 31 * result + (syncDeletes ? 1 : 0);
+        result = 31 * result + (syncProperties ? 1 : 0);
+        result = 31 * result + (repoKey != null ? repoKey.hashCode() : 0);
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "LocalReplicationImpl{" +
+                "url='" + url + '\'' +
+                ", socketTimeoutMillis=" + socketTimeoutMillis +
+                ", username='" + username + '\'' +
+                ", password='" + password + '\'' +
+                ", enableEventReplication=" + enableEventReplication +
+                ", enabled=" + enabled +
+                ", cronExp='" + cronExp + '\'' +
+                ", syncDeletes=" + syncDeletes +
+                ", syncProperties=" + syncProperties +
+                ", repoKey='" + repoKey + '\'' +
+                '}';
+    }
+}

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalReplicationImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalReplicationImpl.java
@@ -9,6 +9,7 @@ public class LocalReplicationImpl implements LocalReplication {
     private String username;
     private String password;
     private boolean enableEventReplication;
+    private boolean syncStatistics;
     private boolean enabled;
     private String cronExp;
     private boolean syncDeletes;
@@ -19,14 +20,15 @@ public class LocalReplicationImpl implements LocalReplication {
     }
 
     LocalReplicationImpl(String url, long socketTimeoutMillis, String username, String password,
-        boolean enableEventReplication, boolean enabled, String cronExp, boolean syncDeletes, boolean syncProperties,
-        String repoKey) {
+        boolean enableEventReplication, boolean syncStatistics, boolean enabled, String cronExp, boolean syncDeletes,
+        boolean syncProperties, String repoKey) {
 
         this.url = url;
         this.socketTimeoutMillis = socketTimeoutMillis;
         this.username = username;
         this.password = password;
         this.enableEventReplication = enableEventReplication;
+        this.syncStatistics = syncStatistics;
         this.enabled = enabled;
         this.cronExp = cronExp;
         this.syncDeletes = syncDeletes;
@@ -80,6 +82,11 @@ public class LocalReplicationImpl implements LocalReplication {
     }
 
     @Override
+    public boolean isSyncStatistics() {
+        return syncStatistics;
+    }
+
+    @Override
     public String getRepoKey() {
         return repoKey;
     }
@@ -93,6 +100,7 @@ public class LocalReplicationImpl implements LocalReplication {
 
         if (socketTimeoutMillis != that.socketTimeoutMillis) return false;
         if (enableEventReplication != that.enableEventReplication) return false;
+        if (syncStatistics != that.syncStatistics) return false;
         if (enabled != that.enabled) return false;
         if (syncDeletes != that.syncDeletes) return false;
         if (syncProperties != that.syncProperties) return false;
@@ -111,6 +119,7 @@ public class LocalReplicationImpl implements LocalReplication {
         result = 31 * result + (username != null ? username.hashCode() : 0);
         result = 31 * result + (password != null ? password.hashCode() : 0);
         result = 31 * result + (enableEventReplication ? 1 : 0);
+        result = 31 * result + (syncStatistics ? 1 : 0);
         result = 31 * result + (enabled ? 1 : 0);
         result = 31 * result + (cronExp != null ? cronExp.hashCode() : 0);
         result = 31 * result + (syncDeletes ? 1 : 0);
@@ -128,6 +137,7 @@ public class LocalReplicationImpl implements LocalReplication {
                 ", username='" + username + '\'' +
                 ", password='" + password + '\'' +
                 ", enableEventReplication=" + enableEventReplication +
+                ", syncStatistics=" + syncStatistics +
                 ", enabled=" + enabled +
                 ", cronExp='" + cronExp + '\'' +
                 ", syncDeletes=" + syncDeletes +

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/RemoteReplicationImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/RemoteReplicationImpl.java
@@ -1,0 +1,85 @@
+package org.jfrog.artifactory.client.model.impl;
+
+import org.jfrog.artifactory.client.model.RemoteReplication;
+
+public class RemoteReplicationImpl implements RemoteReplication {
+
+    private boolean enabled;
+    private String cronExp;
+    private boolean syncDeletes;
+    private boolean syncProperties;
+    private String repoKey;
+
+    RemoteReplicationImpl() {
+    }
+
+    RemoteReplicationImpl(boolean enabled, String cronExp, boolean syncDeletes, boolean syncProperties, String repoKey) {
+        this.enabled = enabled;
+        this.cronExp = cronExp;
+        this.syncDeletes = syncDeletes;
+        this.syncProperties = syncProperties;
+        this.repoKey = repoKey;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public String getCronExp() {
+        return cronExp;
+    }
+
+    @Override
+    public boolean isSyncDeletes() {
+        return syncDeletes;
+    }
+
+    @Override
+    public boolean isSyncProperties() {
+        return syncProperties;
+    }
+
+    @Override
+    public String getRepoKey() {
+        return repoKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RemoteReplicationImpl that = (RemoteReplicationImpl) o;
+
+        if (enabled != that.enabled) return false;
+        if (syncDeletes != that.syncDeletes) return false;
+        if (syncProperties != that.syncProperties) return false;
+        if (cronExp != null ? !cronExp.equals(that.cronExp) : that.cronExp != null) return false;
+
+        return repoKey != null ? repoKey.equals(that.repoKey) : that.repoKey == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + (cronExp != null ? cronExp.hashCode() : 0);
+        result = 31 * result + (syncDeletes ? 1 : 0);
+        result = 31 * result + (syncProperties ? 1 : 0);
+        result = 31 * result + (repoKey != null ? repoKey.hashCode() : 0);
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteReplicationImpl{" +
+                "enabled=" + enabled +
+                ", cronExp='" + cronExp + '\'' +
+                ", syncDeletes=" + syncDeletes +
+                ", syncProperties=" + syncProperties +
+                ", repoKey='" + repoKey + '\'' +
+                '}';
+    }
+}

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
@@ -1,0 +1,422 @@
+package org.jfrog.artifactory.client
+
+import groovyx.net.http.HttpResponseException
+import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
+import org.jfrog.artifactory.client.model.impl.RemoteReplicationImpl
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import static org.testng.Assert.*
+
+public class ReplicationTests extends BaseRepositoryTests {
+
+    @BeforeMethod
+    protected void setUp() {
+        super.setUp()
+    }
+
+    // ======================== //
+    // === Local repository === //
+    // ======================== //
+
+    @Test(groups = "replication")
+    void localRepositoryWithNoReplication_ListReplications() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, localRepo)
+
+        // === Test === //
+
+        def replications = artifactory.repository(localRepo.getKey()).replications
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 0)
+    }
+
+    @Test(groups = "replication")
+    void localRepositoryWithNoReplication_CreateOneReplication() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, localRepo)
+
+        // === Test === //
+
+        def replications = artifactory.repository(localRepo.getKey()).replications
+
+        def replication1 = new LocalReplicationImpl()
+        replication1.url = "http://localhost:12345/artifactory/${localRepo.key}"
+        replication1.socketTimeoutMillis = 30000
+        replication1.username = 'john.doe'
+        replication1.password = 'secret'
+        replication1.enableEventReplication = false
+        replication1.enabled = false
+        replication1.cronExp = '0 0 0/2 * * ?'
+        replication1.syncDeletes = true
+        replication1.syncProperties = true
+        replication1.syncStatistics = true
+        replication1.repoKey = localRepo.key
+
+        replications.createOrReplaceReplication(replication1)
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 1)
+        assertEquals(result[0], replication1)
+    }
+
+    @Test(groups = "replication")
+    void localRepositoryWithNoReplication_CreateTwoReplications() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, localRepo)
+
+        // === Test === //
+
+        def replications = artifactory.repository(localRepo.getKey()).replications
+
+        def replication1 = new LocalReplicationImpl()
+        replication1.url = "http://localhost:12345/artifactory/${localRepo.key}"
+        replication1.socketTimeoutMillis = 30000
+        replication1.username = 'john.doe'
+        replication1.password = 'secret1'
+        replication1.enableEventReplication = false
+        replication1.enabled = false
+        replication1.cronExp = '0 0 0/2 * * ?'
+        replication1.syncDeletes = false
+        replication1.syncProperties = false
+        replication1.syncStatistics = false
+        replication1.repoKey = localRepo.key
+
+        def replication2 = new LocalReplicationImpl()
+        replication2.url = "http://localhost:54321/artifactory/${localRepo.key}"
+        replication2.socketTimeoutMillis = 60000
+        replication2.username = 'jane.doe'
+        replication2.password = 'secret2'
+        replication2.enableEventReplication = true
+        replication2.enabled = true
+        replication2.cronExp = '0 0 0/4 * * ?'
+        replication2.syncDeletes = true
+        replication2.syncProperties = true
+        replication2.syncStatistics = true
+        replication2.repoKey = localRepo.key
+
+        replications.createOrReplaceReplications([ replication1, replication2 ])
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 2)
+
+        // The first replication returns unaltered
+        assertTrue(result.contains(replication1))
+
+        // The second replication has some of its properties (the shared ones) overwritten by the first one !
+        def expected = new LocalReplicationImpl()
+        expected.url = replication2.url
+        expected.socketTimeoutMillis = replication2.socketTimeoutMillis
+        expected.username = replication2.username
+        expected.password = replication2.password
+        expected.enableEventReplication = false // <-- Overwritten !!
+        expected.enabled = replication2.enabled
+        expected.cronExp = '0 0 0/2 * * ?'      // <-- Overwritten !!
+        expected.syncDeletes = replication2.syncDeletes
+        expected.syncProperties = replication2.syncProperties
+        expected.syncStatistics = replication2.syncStatistics
+        expected.repoKey = replication2.repoKey
+
+        assertTrue(result.contains(expected))
+    }
+
+    @Test(groups = "replication", expectedExceptions = [ HttpResponseException ], expectedExceptionsMessageRegExp = "Bad Request")
+    void localRepositoryWithNoReplication_DeleteReplications() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, localRepo)
+
+        // === Test === //
+
+        def replications = artifactory.repository(localRepo.getKey()).replications
+
+        // This call throws a groovyx.net.http.HttpResponseException with the message "Bad Request"
+        replications.delete()
+    }
+
+    @Test(groups = "replication")
+    void localRepositoryWithOneReplication_DeleteReplications() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, localRepo)
+
+        def replications = artifactory.repository(localRepo.getKey()).replications
+
+        def replication1 = new LocalReplicationImpl()
+        replication1.url = "http://localhost:12345/artifactory/${localRepo.key}"
+        replication1.socketTimeoutMillis = 30000
+        replication1.username = 'john.doe'
+        replication1.password = 'secret'
+        replication1.enableEventReplication = false
+        replication1.enabled = false
+        replication1.cronExp = '0 0 0/2 * * ?'
+        replication1.syncDeletes = true
+        replication1.syncProperties = true
+        replication1.syncStatistics = true
+        replication1.repoKey = localRepo.key
+
+        replications.createOrReplaceReplication(replication1)
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 1)
+
+        // === Test === //
+
+        replications.delete()
+
+        def result2 = replications.list()
+
+        assertNotNull(result2)
+        assertEquals(result2.size(), 0)
+    }
+
+    @Test(groups = "replication")
+    void localRepositoryWithOneReplication_ReplaceReplication() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, localRepo)
+
+        def replications = artifactory.repository(localRepo.getKey()).replications
+
+        def replication1 = new LocalReplicationImpl()
+        replication1.url = "http://localhost:12345/artifactory/${localRepo.key}"
+        replication1.socketTimeoutMillis = 30000
+        replication1.username = 'john.doe'
+        replication1.password = 'secret'
+        replication1.enableEventReplication = false
+        replication1.enabled = false
+        replication1.cronExp = '0 0 0/2 * * ?'
+        replication1.syncDeletes = true
+        replication1.syncProperties = true
+        replication1.syncStatistics = true
+        replication1.repoKey = localRepo.key
+
+        replications.createOrReplaceReplication(replication1)
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 1)
+        assertEquals(result[0], replication1)
+
+        // === Test === //
+
+        // Alter some properties from the replication
+        replication1.enabled = !replication1.enabled
+        replication1.syncDeletes = !replication1.syncDeletes
+
+        replications.createOrReplaceReplication(replication1)
+
+        def result2 = replications.list()
+
+        assertNotNull(result2)
+        assertEquals(result2.size(), 1)
+        assertEquals(result2[0], replication1)
+    }
+
+    @Test(groups = "replication")
+    void localRepositoryWithTwoReplications_DeleteReplications() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, localRepo)
+
+        def replications = artifactory.repository(localRepo.getKey()).replications
+
+        def replication1 = new LocalReplicationImpl()
+        replication1.url = "http://localhost:12345/artifactory/${localRepo.key}"
+        replication1.socketTimeoutMillis = 30000
+        replication1.username = 'john.doe'
+        replication1.password = 'secret1'
+        replication1.enableEventReplication = false
+        replication1.enabled = false
+        replication1.cronExp = '0 0 0/2 * * ?'
+        replication1.syncDeletes = false
+        replication1.syncProperties = false
+        replication1.syncStatistics = false
+        replication1.repoKey = localRepo.key
+
+        def replication2 = new LocalReplicationImpl()
+        replication2.url = "http://localhost:54321/artifactory/${localRepo.key}"
+        replication2.socketTimeoutMillis = 60000
+        replication2.username = 'jane.doe'
+        replication2.password = 'secret2'
+        replication2.enableEventReplication = true
+        replication2.enabled = true
+        replication2.cronExp = '0 0 0/4 * * ?'
+        replication2.syncDeletes = true
+        replication2.syncProperties = true
+        replication2.syncStatistics = true
+        replication2.repoKey = localRepo.key
+
+        replications.createOrReplaceReplications([replication1, replication2])
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 2)
+
+        // === Test === //
+
+        replications.delete()
+
+        def result2 = replications.list()
+
+        assertNotNull(result2)
+        assertEquals(result2.size(), 0)
+    }
+
+    // ========================= //
+    // === Remote repository === //
+    // ========================= //
+
+    @Test(groups = "replication")
+    void remoteRepositoryWithNoReplication_ListReplications() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, remoteRepo)
+
+        // === Test === //
+
+        def replications = artifactory.repository(remoteRepo.getKey()).replications
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 0)
+    }
+
+    @Test(groups = "replication")
+    void remoteRepositoryWithNoReplication_CreateOneReplication() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, remoteRepo)
+
+        // === Test === //
+
+        def replications = artifactory.repository(remoteRepo.getKey()).replications
+
+        def replication1 = new RemoteReplicationImpl()
+        replication1.enabled = false
+        replication1.cronExp = '0 0 0/2 * * ?'
+        replication1.syncDeletes = true
+        replication1.syncProperties = true
+        replication1.repoKey = remoteRepo.key
+
+        replications.createOrReplaceReplication(replication1)
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 1)
+        assertEquals(result[0], replication1)
+    }
+
+    @Test(groups = "replication", expectedExceptions = [ HttpResponseException ], expectedExceptionsMessageRegExp = "Bad Request")
+    void remoteRepositoryWithNoReplication_DeleteReplications() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, remoteRepo)
+
+        // === Test === //
+
+        def replications = artifactory.repository(remoteRepo.getKey()).replications
+
+        // This call throws a groovyx.net.http.HttpResponseException with the message "Bad Request"
+        replications.delete()
+    }
+
+    @Test(groups = "replication")
+    void remoteRepositoryWithOneReplication_DeleteReplications() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, remoteRepo)
+
+        def replications = artifactory.repository(remoteRepo.getKey()).replications
+
+        def replication1 = new RemoteReplicationImpl()
+        replication1.enabled = false
+        replication1.cronExp = '0 0 0/2 * * ?'
+        replication1.syncDeletes = true
+        replication1.syncProperties = true
+        replication1.repoKey = remoteRepo.key
+
+        replications.createOrReplaceReplication(replication1)
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 1)
+
+        // === Test === //
+
+        replications.delete()
+
+        def result2 = replications.list()
+
+        assertNotNull(result2)
+        assertEquals(result2.size(), 0)
+    }
+
+    @Test(groups = "replication")
+    void remoteRepositoryWithOneReplication_ReplaceReplication() {
+
+        // === Setup === //
+
+        artifactory.repositories().create(0, remoteRepo)
+
+        def replications = artifactory.repository(remoteRepo.getKey()).replications
+
+        def replication1 = new RemoteReplicationImpl()
+        replication1.enabled = false
+        replication1.cronExp = '0 0 0/2 * * ?'
+        replication1.syncDeletes = true
+        replication1.syncProperties = true
+        replication1.repoKey = remoteRepo.key
+
+        replications.createOrReplaceReplication(replication1)
+
+        def result = replications.list()
+
+        assertNotNull(result)
+        assertEquals(result.size(), 1)
+        assertEquals(result[0], replication1)
+
+        // === Test === //
+
+        // Alter some properties from the replication
+        replication1.enabled = !replication1.enabled
+        replication1.syncDeletes = !replication1.syncDeletes
+
+        replications.createOrReplaceReplication(replication1)
+
+        def result2 = replications.list()
+
+        assertNotNull(result2)
+        assertEquals(result2.size(), 1)
+        assertEquals(result2[0], replication1)
+    }
+}

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
@@ -1,7 +1,6 @@
 package org.jfrog.artifactory.client
 
 import groovyx.net.http.HttpResponseException
-import org.hamcrest.CoreMatchers
 import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
 import org.jfrog.artifactory.client.model.impl.RemoteReplicationImpl
 import org.testng.annotations.BeforeMethod
@@ -61,7 +60,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncStatistics = true
         replication1.repoKey = localRepo.key
 
-        replications.createOrReplaceReplication(replication1)
+        replications.createOrReplace(replication1)
 
         def result = replications.list()
 
@@ -107,7 +106,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication2.syncStatistics = true
         replication2.repoKey = localRepo.key
 
-        replications.createOrReplaceReplications([ replication1, replication2 ])
+        replications.createOrReplace([replication1, replication2 ])
 
         def result = replications.list()
 
@@ -171,7 +170,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncStatistics = true
         replication1.repoKey = localRepo.key
 
-        replications.createOrReplaceReplication(replication1)
+        replications.createOrReplace(replication1)
 
         def result = replications.list()
 
@@ -210,7 +209,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncStatistics = true
         replication1.repoKey = localRepo.key
 
-        replications.createOrReplaceReplication(replication1)
+        replications.createOrReplace(replication1)
 
         def result = replications.list()
 
@@ -224,7 +223,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.enabled = !replication1.enabled
         replication1.syncDeletes = !replication1.syncDeletes
 
-        replications.createOrReplaceReplication(replication1)
+        replications.createOrReplace(replication1)
 
         def result2 = replications.list()
 
@@ -268,7 +267,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication2.syncStatistics = true
         replication2.repoKey = localRepo.key
 
-        replications.createOrReplaceReplications([replication1, replication2])
+        replications.createOrReplace([replication1, replication2])
 
         def result = replications.list()
 
@@ -324,7 +323,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncProperties = true
         replication1.repoKey = remoteRepo.key
 
-        replications.createOrReplaceReplication(replication1)
+        replications.createOrReplace(replication1)
 
         def result = replications.list()
 
@@ -364,7 +363,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncProperties = true
         replication1.repoKey = remoteRepo.key
 
-        replications.createOrReplaceReplication(replication1)
+        replications.createOrReplace(replication1)
 
         def result = replications.list()
 
@@ -397,7 +396,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncProperties = true
         replication1.repoKey = remoteRepo.key
 
-        replications.createOrReplaceReplication(replication1)
+        replications.createOrReplace(replication1)
 
         def result = replications.list()
 
@@ -411,7 +410,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.enabled = !replication1.enabled
         replication1.syncDeletes = !replication1.syncDeletes
 
-        replications.createOrReplaceReplication(replication1)
+        replications.createOrReplace(replication1)
 
         def result2 = replications.list()
 


### PR DESCRIPTION
This PR provides the following new features.

For local repositories:
- Ability to list the replication(s) defined
- Ability to delete the replication(s) defined
- Ability to create / replace the replication(s) defined

For remote repositories:
- Ability to list the replication defined
- Ability to delete the replication defined
- Ability to create / replace the replication

Here's a small Groovy test class I used locally against AF 5.2 to test the new features.

```
static void main(String[] args) {
    if (args.length != 3) {
        println "usage: Main <url> <user> <password>"

        System.exit(1)
    }

    def url = args[0]
    def user = args[1]
    def password = args[2]

    def artifactory = ArtifactoryClientBuilder.create().setUrl(url)
            .setUsername(user)
            .setPassword(password)
            .build()

    // === Local repository tests === //

    local_repository: {

        def repositoryKey = 'test-local-repository'

        if (artifactory.repositories().repository(repositoryKey).exists()) {
            // Delete the repository first
            artifactory.repositories().repository(repositoryKey).delete()
        }

        def localRepository = artifactory.repositories().builders().localRepositoryBuilder()
                .key(repositoryKey)
                .build()

        println "Creating test repository '${repositoryKey}' ..."

        artifactory.repositories().create(0, localRepository)

        println "Created test repository '${repositoryKey}'"

        def replications = artifactory.repositories().repository(repositoryKey).replications

        try {
            // Prepare some test data
            def replication1 = new LocalReplicationImpl()
            replication1.url = "http://localhost:12345/artifactory/${repositoryKey}"
            replication1.socketTimeoutMillis = 30000
            replication1.username = 'john.doe'
            replication1.password = 'secret'
            replication1.enableEventReplication = false
            replication1.enabled = false
            replication1.cronExp = '0 0 0/2 * * ?'
            replication1.syncDeletes = true
            replication1.syncProperties = true
            replication1.syncStatistics = true
            replication1.repoKey = repositoryKey

            def replication2 = new LocalReplicationImpl()
            replication2.url = "http://localhost:54321/artifactory/${repositoryKey}"
            replication2.socketTimeoutMillis = 30000
            replication2.username = 'jane.doe'
            replication2.password = 'secret'
            replication2.enableEventReplication = false
            replication2.enabled = false
            replication2.cronExp = '0 0 0/4 * * ?'
            replication2.syncDeletes = false
            replication2.syncProperties = false
            replication2.syncStatistics = false
            replication2.repoKey = repositoryKey

            // The repo has no replication defined
            def r1 = replications.list()

            assert (r1 != null) && r1.empty

            // === Create one replication === //

            replications.createOrReplaceReplication(replication1)

            // The repo defines one replication
            def r2 = replications.list()

            assert (r2 != null) && (r2.size() == 1)

            // === Delete the replication === //

            replications.delete()

            // The repo has no replication defined
            def r3 = replications.list()

            assert (r3 != null) && r3.empty

            // === Create two replications === //

            replications.createOrReplaceReplications([ replication1, replication2 ])

            // The repo defines two replications
            def r4 = replications.list()

            assert (r4 != null) && (r4.size() == 2)

            // === Delete the replications === //

            replications.delete()

            // The repo has no replication defined
            def r5 = replications.list()

            assert (r5 != null) && r5.empty
        } finally {
            println "Deleting test repository '${repositoryKey}' ..."

            artifactory.repositories().repository(repositoryKey).delete()

            println "Deleted test repository '${repositoryKey}'"
        }
    }

    // === Remote repository tests === //

    remote_repository: {

        def repositoryKey = 'test-remote-repository'

        if (artifactory.repositories().repository(repositoryKey).exists()) {
            // Delete the repository first
            artifactory.repositories().repository(repositoryKey).delete()
        }

        def remoteRepository = artifactory.repositories().builders().remoteRepositoryBuilder()
                .key(repositoryKey)
                .url('http://repo1.maven.org/maven2')
                .build()

        println "Creating test repository '${repositoryKey}' ..."

        artifactory.repositories().create(0, remoteRepository)

        println "Created test repository '${repositoryKey}'"

        def replications = artifactory.repositories().repository(repositoryKey).replications

        try {
            // Prepare some test data
            def replication1 = new RemoteReplicationImpl()
            replication1.enabled = false
            replication1.cronExp = '0 0 0/2 * * ?'
            replication1.syncDeletes = true
            replication1.syncProperties = true
            replication1.repoKey = repositoryKey

            // The repo has no replication defined
            def r1 = replications.list()

            assert (r1 != null) && r1.empty

            // === Create one replication === //

            replications.createOrReplaceReplication(replication1)

            // The repo defines one replication
            def r2 = replications.list()

            assert (r2 != null) && (r2.size() == 1)

            // === Delete the replication === //

            replications.delete()

            // The repo has no replication defined
            def r3 = replications.list()

            assert (r3 != null) && r3.empty
        } finally {
            println "Deleting test repository '${repositoryKey}' ..."

            artifactory.repositories().repository(repositoryKey).delete()

            println "Deleted test repository '${repositoryKey}'"
        }
    }
}
```

I tried to stay consistent with the existing API style.

You may not like the implementation of method `org.jfrog.artifactory.client.impl.ReplicationsImpl#list` but I'm currently using AF 4.11 in production and the structure of the JSON response for the service `Get Repository Replication Configuration` changed in version 4.15 (as per the release notes). The implementation is meant to work with older versions of AF. If the API is only meant to work with the latest version of AF, let me know and I'll simplify the code.

Likewise the implementation of `org.jfrog.artifactory.client.impl.ReplicationsImpl#createOrReplaceReplications` will probably make you yell but that was the simplest I could find to adapt the output of [Get Repository Replication Configuration](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-GetRepositoryReplicationConfiguration) into the input of [Create or Replace Local Multi-push Replication](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-CreateorReplaceLocalMulti-pushReplication)