### PR TITLE
Fixed the cloning of a virtual repository's configuration

### DIFF
--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuildersImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuildersImpl.groovy
@@ -58,6 +58,7 @@ class RepositoryBuildersImpl implements RepositoryBuilders {
     VirtualRepositoryBuilder builderFrom(VirtualRepository from) {
         new VirtualRepositoryBuilderImpl().repositorySettings(from.repositorySettings).description(from.description).excludesPattern(from.excludesPattern).includesPattern(from.includesPattern).key(from.key)
                 .notes(from.notes)
+                .repoLayoutRef(from.repoLayoutRef)
                 .artifactoryRequestsCanRetrieveRemoteArtifacts(from.artifactoryRequestsCanRetrieveRemoteArtifacts).repositories(from.repositories)
                 .defaultDeploymentRepo(from.defaultDeploymentRepo)
     }


### PR DESCRIPTION
The cloning logic used to not copy the "repoLayoutRef" property