### PR TITLE
Added missing property org.jfrog.artifactory.client.model.LocalReplic…

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ replication1.cronExp = '0 0 0/2 * * ?'
 replication1.syncDeletes = true
 replication1.syncProperties = true
 replication1.syncStatistics = true
+replication1.pathPrefix = ''
 replication1.repoKey = "RepoName"
 
 def replication2 = new LocalReplicationImpl()
@@ -246,6 +247,7 @@ replication2.cronExp = '0 0 0/4 * * ?'
 replication2.syncDeletes = true
 replication2.syncProperties = true
 replication2.syncStatistics = true
+replication1.pathPrefix = 'pathPrefix'
 replication2.repoKey = "RepoName"
 
 // Create (or replace) one replication

--- a/api/src/main/java/org/jfrog/artifactory/client/model/LocalReplication.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/LocalReplication.java
@@ -13,4 +13,6 @@ public interface LocalReplication extends Replication {
     boolean isEnableEventReplication();
 
     boolean isSyncStatistics();
+
+    String getPathPrefix();
 }

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalReplicationImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalReplicationImpl.java
@@ -14,6 +14,7 @@ public class LocalReplicationImpl implements LocalReplication {
     private String cronExp;
     private boolean syncDeletes;
     private boolean syncProperties;
+    private String pathPrefix;
     private String repoKey;
 
     LocalReplicationImpl() {
@@ -21,7 +22,7 @@ public class LocalReplicationImpl implements LocalReplication {
 
     LocalReplicationImpl(String url, long socketTimeoutMillis, String username, String password,
         boolean enableEventReplication, boolean syncStatistics, boolean enabled, String cronExp, boolean syncDeletes,
-        boolean syncProperties, String repoKey) {
+        boolean syncProperties, String pathPrefix, String repoKey) {
 
         this.url = url;
         this.socketTimeoutMillis = socketTimeoutMillis;
@@ -33,6 +34,7 @@ public class LocalReplicationImpl implements LocalReplication {
         this.cronExp = cronExp;
         this.syncDeletes = syncDeletes;
         this.syncProperties = syncProperties;
+        this.pathPrefix = pathPrefix;
         this.repoKey = repoKey;
     }
 
@@ -87,6 +89,11 @@ public class LocalReplicationImpl implements LocalReplication {
     }
 
     @Override
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
+
+    @Override
     public String getRepoKey() {
         return repoKey;
     }
@@ -108,6 +115,7 @@ public class LocalReplicationImpl implements LocalReplication {
         if (username != null ? !username.equals(that.username) : that.username != null) return false;
         if (password != null ? !password.equals(that.password) : that.password != null) return false;
         if (cronExp != null ? !cronExp.equals(that.cronExp) : that.cronExp != null) return false;
+        if (pathPrefix != null ? !pathPrefix.equals(that.pathPrefix) : that.pathPrefix != null) return false;
 
         return repoKey != null ? repoKey.equals(that.repoKey) : that.repoKey == null;
     }
@@ -124,6 +132,7 @@ public class LocalReplicationImpl implements LocalReplication {
         result = 31 * result + (cronExp != null ? cronExp.hashCode() : 0);
         result = 31 * result + (syncDeletes ? 1 : 0);
         result = 31 * result + (syncProperties ? 1 : 0);
+        result = 31 * result + (pathPrefix != null ? pathPrefix.hashCode() : 0);
         result = 31 * result + (repoKey != null ? repoKey.hashCode() : 0);
 
         return result;
@@ -142,6 +151,7 @@ public class LocalReplicationImpl implements LocalReplication {
                 ", cronExp='" + cronExp + '\'' +
                 ", syncDeletes=" + syncDeletes +
                 ", syncProperties=" + syncProperties +
+                ", pathPrefix='" + pathPrefix + '\'' +
                 ", repoKey='" + repoKey + '\'' +
                 '}';
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
@@ -58,7 +58,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncDeletes = true
         replication1.syncProperties = true
         replication1.syncStatistics = true
-        replication1.pathPrefix = ''
+        replication1.pathPrefix = 'pathPrefix'
         replication1.repoKey = localRepo.key
 
         replications.createOrReplace(replication1)
@@ -172,7 +172,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncDeletes = true
         replication1.syncProperties = true
         replication1.syncStatistics = true
-        replication1.pathPrefix = ''
+        replication1.pathPrefix = 'pathPrefix'
         replication1.repoKey = localRepo.key
 
         replications.createOrReplace(replication1)
@@ -212,7 +212,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncDeletes = true
         replication1.syncProperties = true
         replication1.syncStatistics = true
-        replication1.pathPrefix = ''
+        replication1.pathPrefix = 'pathPrefix'
         replication1.repoKey = localRepo.key
 
         replications.createOrReplace(replication1)
@@ -258,7 +258,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncDeletes = false
         replication1.syncProperties = false
         replication1.syncStatistics = false
-        replication1.pathPrefix = ''
+        replication1.pathPrefix = 'pathPrefix'
         replication1.repoKey = localRepo.key
 
         def replication2 = new LocalReplicationImpl()

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
@@ -58,6 +58,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncDeletes = true
         replication1.syncProperties = true
         replication1.syncStatistics = true
+        replication1.pathPrefix = ''
         replication1.repoKey = localRepo.key
 
         replications.createOrReplace(replication1)
@@ -91,6 +92,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncDeletes = false
         replication1.syncProperties = false
         replication1.syncStatistics = false
+        replication1.pathPrefix = null // <-- the test fails when trying to use a non-null value, the server doesn't return the 'pathPrefix' property when listing the replications later
         replication1.repoKey = localRepo.key
 
         def replication2 = new LocalReplicationImpl()
@@ -104,9 +106,10 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication2.syncDeletes = true
         replication2.syncProperties = true
         replication2.syncStatistics = true
+        replication2.pathPrefix = null // <-- the test fails when trying to use a non-null value, the server doesn't return the 'pathPrefix' property when listing the replications later
         replication2.repoKey = localRepo.key
 
-        replications.createOrReplace([replication1, replication2 ])
+        replications.createOrReplace([ replication1, replication2 ])
 
         def result = replications.list()
 
@@ -128,6 +131,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         expected.syncDeletes = replication2.syncDeletes
         expected.syncProperties = replication2.syncProperties
         expected.syncStatistics = replication2.syncStatistics
+        expected.pathPrefix = null
         expected.repoKey = replication2.repoKey
 
         assertTrue(result.contains(expected))
@@ -168,6 +172,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncDeletes = true
         replication1.syncProperties = true
         replication1.syncStatistics = true
+        replication1.pathPrefix = ''
         replication1.repoKey = localRepo.key
 
         replications.createOrReplace(replication1)
@@ -207,6 +212,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncDeletes = true
         replication1.syncProperties = true
         replication1.syncStatistics = true
+        replication1.pathPrefix = ''
         replication1.repoKey = localRepo.key
 
         replications.createOrReplace(replication1)
@@ -252,6 +258,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication1.syncDeletes = false
         replication1.syncProperties = false
         replication1.syncStatistics = false
+        replication1.pathPrefix = ''
         replication1.repoKey = localRepo.key
 
         def replication2 = new LocalReplicationImpl()
@@ -265,6 +272,7 @@ public class ReplicationTests extends BaseRepositoryTests {
         replication2.syncDeletes = true
         replication2.syncProperties = true
         replication2.syncStatistics = true
+        replication2.pathPrefix = 'dummy'
         replication2.repoKey = localRepo.key
 
         replications.createOrReplace([replication1, replication2])


### PR DESCRIPTION
…ation#getPathPrefix

I realized while testing the code to create / update replications (from a previous PR) that I had forgotten about the "pathPrefix" property for local repository replications. 

I didn't catch this previously because the "pathPrefix" properly is optional (in which case the server doesn't return the property in the JSON response).

Can you please merge this change ?