### PR TITLE
Add the right layout type while creating repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ Repository repository = artifactory.repositories()
 String result = artifactory.repositories().create(2, repository);
 ```
 
+###### Repository Settings
+
+For choosing your repository characteristic, use the right settings, each one of them possess the relevant attributes available in Artifactory.
+
+Example for using generic repository with maven layout:
+```
+RepositorySettings settings = new GenericRepositorySettingsImpl()
+settings.setRepoLayout("maven-2-default")
+```
+
 ##### Updating Repositories
 ```
 Repository repository = artifactory.repository("RepoName").get();

--- a/api/src/main/java/org/jfrog/artifactory/client/model/PackageType.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/PackageType.java
@@ -7,4 +7,6 @@ public interface PackageType {
     String name();
 
     boolean isCustom();
+
+    String getLayout();
 }

--- a/api/src/main/java/org/jfrog/artifactory/client/model/PackageType.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/PackageType.java
@@ -7,6 +7,4 @@ public interface PackageType {
     String name();
 
     boolean isCustom();
-
-    String getLayout();
 }

--- a/api/src/main/java/org/jfrog/artifactory/client/model/builder/RepositoryBuilder.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/builder/RepositoryBuilder.java
@@ -40,6 +40,8 @@ public interface RepositoryBuilder<B extends RepositoryBuilder, R extends Reposi
 
     void validate();
 
+    void setRepoLayout();
+
     B repositorySettings(RepositorySettings settings);
 
     RepositorySettings getRepositorySettings();

--- a/api/src/main/java/org/jfrog/artifactory/client/model/builder/RepositoryBuilder.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/builder/RepositoryBuilder.java
@@ -32,10 +32,6 @@ public interface RepositoryBuilder<B extends RepositoryBuilder, R extends Reposi
 
     String getNotes();
 
-    B repoLayoutRef(String repoLayoutRef);
-
-    String getRepoLayoutRef();
-
     R build();
 
     void validate();

--- a/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/AbstractRepositorySettings.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/AbstractRepositorySettings.java
@@ -1,0 +1,16 @@
+package org.jfrog.artifactory.client.model.repository.settings;
+
+/**
+ * @author Lior Hasson
+ */
+public abstract class AbstractRepositorySettings implements RepositorySettings {
+    protected String repoLayoutRef;
+
+    public String getRepoLayout() {
+        return this.repoLayoutRef;
+    }
+
+    public void setRepoLayout(String repoLayout) {
+        this.repoLayoutRef = repoLayout;
+    }
+}

--- a/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/RepositorySettings.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/RepositorySettings.java
@@ -8,4 +8,8 @@ import org.jfrog.artifactory.client.model.PackageType;
 public interface RepositorySettings {
 
     PackageType getPackageType();
+
+    String getRepoLayout();
+
+    void setRepoLayout(String repoLayout);
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalRepositoryBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalRepositoryBuilderImpl.groovy
@@ -1,7 +1,6 @@
 package org.jfrog.artifactory.client.model.builder.impl
 
 import org.jfrog.artifactory.client.model.LocalRepository
-import org.jfrog.artifactory.client.model.Repository
 import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.builder.LocalRepositoryBuilder
 import org.jfrog.artifactory.client.model.impl.LocalRepositoryImpl
@@ -19,11 +18,12 @@ class LocalRepositoryBuilderImpl extends NonVirtualRepositoryBuilderBase<LocalRe
     private LocalRepositoryBuilderImpl() {
         super([bower, cocoapods, debian, docker, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, opkg, pypi,
                sbt, vagrant, yum, rpm, composer, conan, chef, puppet] as Set)
-        this.repoLayoutRef = Repository.MAVEN_2_REPO_LAYOUT
     }
 
     LocalRepository build() {
         validate()
+        setRepoLayout()
+
         return new LocalRepositoryImpl(key, settings, xraySettings, description, excludesPattern,
             includesPattern, notes, blackedOut,
             propertySets,

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteRepositoryBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteRepositoryBuilderImpl.groovy
@@ -278,6 +278,7 @@ class RemoteRepositoryBuilderImpl extends NonVirtualRepositoryBuilderBase<Remote
     @SuppressWarnings("GroovyAccessibility")
     RemoteRepository build() {
         validate()
+        setRepoLayout()
 
         new RemoteRepositoryImpl(key, settings, xraySettings, contentSync, description, excludesPattern,
                 includesPattern, notes, blackedOut, propertySets, failedRetrievalCachePeriodSecs,

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuilderBase.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuilderBase.groovy
@@ -84,17 +84,6 @@ abstract class RepositoryBuilderBase<B extends RepositoryBuilder, R extends Repo
     }
 
     @Override
-    B repoLayoutRef(String repoLayoutRef) {
-        this.repoLayoutRef = repoLayoutRef
-        this as B
-    }
-
-    @Override
-    String getRepoLayoutRef() {
-        repoLayoutRef
-    }
-
-    @Override
     B repositorySettings(RepositorySettings settings) {
         this.settings = settings
         this as B
@@ -142,7 +131,7 @@ abstract class RepositoryBuilderBase<B extends RepositoryBuilder, R extends Repo
     void setRepoLayout() {
         if(this.repoLayoutRef == null) {
             if(settings != null){
-                this.repoLayoutRef = settings.packageType.layout
+                this.repoLayoutRef = settings.getRepoLayout()
             }
         }
     }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuilderBase.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuilderBase.groovy
@@ -137,4 +137,13 @@ abstract class RepositoryBuilderBase<B extends RepositoryBuilder, R extends Repo
             throw new IllegalArgumentException("Package type '${settings.packageType}' is not supported in $repositoryType repositories");
         }
     }
+
+    @Override
+    void setRepoLayout() {
+        if(this.repoLayoutRef == null) {
+            if(settings != null){
+                this.repoLayoutRef = settings.packageType.layout
+            }
+        }
+    }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuildersImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuildersImpl.groovy
@@ -48,7 +48,7 @@ class RepositoryBuildersImpl implements RepositoryBuilders {
         new LocalRepositoryBuilderImpl().repositorySettings(from.repositorySettings).blackedOut(from.blackedOut).description(from.description)
                 .excludesPattern(from.excludesPattern).includesPattern(from.includesPattern)
                 .key(from.key).notes(from.notes).propertySets(from.propertySets)
-                .repoLayoutRef(from.repoLayoutRef).archiveBrowsingEnabled(from.archiveBrowsingEnabled)
+                .archiveBrowsingEnabled(from.archiveBrowsingEnabled)
     }
 
     VirtualRepositoryBuilder virtualRepositoryBuilder() {
@@ -58,7 +58,6 @@ class RepositoryBuildersImpl implements RepositoryBuilders {
     VirtualRepositoryBuilder builderFrom(VirtualRepository from) {
         new VirtualRepositoryBuilderImpl().repositorySettings(from.repositorySettings).description(from.description).excludesPattern(from.excludesPattern).includesPattern(from.includesPattern).key(from.key)
                 .notes(from.notes)
-                .repoLayoutRef(from.repoLayoutRef)
                 .artifactoryRequestsCanRetrieveRemoteArtifacts(from.artifactoryRequestsCanRetrieveRemoteArtifacts).repositories(from.repositories)
                 .defaultDeploymentRepo(from.defaultDeploymentRepo)
     }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/VirtualRepositoryBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/VirtualRepositoryBuilderImpl.groovy
@@ -56,6 +56,8 @@ class VirtualRepositoryBuilderImpl extends RepositoryBuilderBase<VirtualReposito
 
     VirtualRepository build() {
         validate()
+        setRepoLayout()
+
         new VirtualRepositoryImpl(key, settings, description, excludesPattern,
             includesPattern, notes, artifactoryRequestsCanRetrieveRemoteArtifacts,
             repositories, repoLayoutRef, defaultDeploymentRepo, customProperties)

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/BowerRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/BowerRepositorySettingsImpl.groovy
@@ -17,6 +17,10 @@ class BowerRepositorySettingsImpl extends VcsRepositorySettingsImpl implements B
     Collection<String> externalDependenciesPatterns
     String externalDependenciesRemoteRepo
 
+    public BowerRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.bower.layout
+    }
+
     @Override
     public PackageType getPackageType() {
         return PackageTypeImpl.bower

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/BowerRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/BowerRepositorySettingsImpl.groovy
@@ -12,13 +12,15 @@ import org.jfrog.artifactory.client.model.repository.settings.BowerRepositorySet
  */
 @EqualsAndHashCode
 class BowerRepositorySettingsImpl extends VcsRepositorySettingsImpl implements BowerRepositorySettings {
+    static defaultLayout = "bower-default"
+
     String bowerRegistryUrl
     Boolean externalDependenciesEnabled
     Collection<String> externalDependenciesPatterns
     String externalDependenciesRemoteRepo
 
     public BowerRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.bower.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ChefRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ChefRepositorySettingsImpl.groovy
@@ -3,10 +3,15 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.ChefRepositorySettings
 
 @EqualsAndHashCode
-class ChefRepositorySettingsImpl implements ChefRepositorySettings {
+class ChefRepositorySettingsImpl extends AbstractRepositorySettings implements ChefRepositorySettings {
+
+    public ChefRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.chef.layout
+    }
 
     @Override
     PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ChefRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ChefRepositorySettingsImpl.groovy
@@ -8,9 +8,10 @@ import org.jfrog.artifactory.client.model.repository.settings.ChefRepositorySett
 
 @EqualsAndHashCode
 class ChefRepositorySettingsImpl extends AbstractRepositorySettings implements ChefRepositorySettings {
+    static defaultLayout = "simple-default"
 
     public ChefRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.chef.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/CocoaPodsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/CocoaPodsRepositorySettingsImpl.groovy
@@ -14,6 +14,10 @@ import org.jfrog.artifactory.client.model.repository.settings.CocoaPodsRepositor
 class CocoaPodsRepositorySettingsImpl extends VcsRepositorySettingsImpl implements CocoaPodsRepositorySettings {
     String podsSpecsRepoUrl
 
+    public CocoaPodsRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.cocoapods.layout
+    }
+
     @Override
     public PackageType getPackageType() {
         return PackageTypeImpl.cocoapods

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/CocoaPodsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/CocoaPodsRepositorySettingsImpl.groovy
@@ -12,10 +12,12 @@ import org.jfrog.artifactory.client.model.repository.settings.CocoaPodsRepositor
  */
 @EqualsAndHashCode
 class CocoaPodsRepositorySettingsImpl extends VcsRepositorySettingsImpl implements CocoaPodsRepositorySettings {
+    static defaultLayout = "simple-default"
+
     String podsSpecsRepoUrl
 
     public CocoaPodsRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.cocoapods.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ComposerRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ComposerRepositorySettingsImpl.groovy
@@ -10,6 +10,10 @@ class ComposerRepositorySettingsImpl extends VcsRepositorySettingsImpl implement
 
     String composerRegistryUrl
 
+    public ComposerRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.composer.layout
+    }
+
     @Override
     PackageType getPackageType() {
       return PackageTypeImpl.composer

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ComposerRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ComposerRepositorySettingsImpl.groovy
@@ -7,11 +7,12 @@ import org.jfrog.artifactory.client.model.repository.settings.ComposerRepository
 
 @EqualsAndHashCode
 class ComposerRepositorySettingsImpl extends VcsRepositorySettingsImpl implements ComposerRepositorySettings {
+    static defaultLayout = "composer-default"
 
     String composerRegistryUrl
 
     public ComposerRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.composer.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ConanRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ConanRepositorySettingsImpl.groovy
@@ -8,9 +8,10 @@ import org.jfrog.artifactory.client.model.repository.settings.ConanRepositorySet
 
 @EqualsAndHashCode
 class ConanRepositorySettingsImpl extends AbstractRepositorySettings implements ConanRepositorySettings {
+    static String defaultLayout = "conan-default"
 
     public ConanRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.conan.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ConanRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ConanRepositorySettingsImpl.groovy
@@ -3,10 +3,15 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.ConanRepositorySettings
 
 @EqualsAndHashCode
-class ConanRepositorySettingsImpl implements ConanRepositorySettings {
+class ConanRepositorySettingsImpl extends AbstractRepositorySettings implements ConanRepositorySettings {
+
+    public ConanRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.conan.layout
+    }
 
     @Override
     PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DebianRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DebianRepositorySettingsImpl.groovy
@@ -13,11 +13,13 @@ import org.jfrog.artifactory.client.model.repository.settings.DebianRepositorySe
  */
 @EqualsAndHashCode
 class DebianRepositorySettingsImpl extends AbstractRepositorySettings implements DebianRepositorySettings {
+    static String defaultLayout = "simple-default"
+
     Boolean debianTrivialLayout
     Boolean listRemoteFolderItems
 
     public DebianRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.debian.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DebianRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DebianRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.DebianRepositorySettings
 
 /**
@@ -11,9 +12,13 @@ import org.jfrog.artifactory.client.model.repository.settings.DebianRepositorySe
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class DebianRepositorySettingsImpl implements DebianRepositorySettings {
+class DebianRepositorySettingsImpl extends AbstractRepositorySettings implements DebianRepositorySettings {
     Boolean debianTrivialLayout
     Boolean listRemoteFolderItems
+
+    public DebianRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.debian.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.DockerRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.docker.DockerApiVersion
 
@@ -12,11 +13,15 @@ import org.jfrog.artifactory.client.model.repository.settings.docker.DockerApiVe
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-public class DockerRepositorySettingsImpl implements DockerRepositorySettings{
+public class DockerRepositorySettingsImpl extends AbstractRepositorySettings implements DockerRepositorySettings{
     DockerApiVersion dockerApiVersion
     Boolean enableTokenAuthentication
     Boolean listRemoteFolderItems
     Integer maxUniqueTags
+
+    public DockerRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.docker.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.groovy
@@ -14,13 +14,15 @@ import org.jfrog.artifactory.client.model.repository.settings.docker.DockerApiVe
  */
 @EqualsAndHashCode
 public class DockerRepositorySettingsImpl extends AbstractRepositorySettings implements DockerRepositorySettings{
+    static String defaultLayout = "simple-default"
+
     DockerApiVersion dockerApiVersion
     Boolean enableTokenAuthentication
     Boolean listRemoteFolderItems
     Integer maxUniqueTags
 
     public DockerRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.docker.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GemsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GemsRepositorySettingsImpl.groovy
@@ -13,10 +13,12 @@ import org.jfrog.artifactory.client.model.repository.settings.GemsRepositorySett
  */
 @EqualsAndHashCode
 class GemsRepositorySettingsImpl extends AbstractRepositorySettings implements GemsRepositorySettings {
+    static String defaultLayout = "simple-default"
+
     Boolean listRemoteFolderItems
 
     public GemsRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.gems.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GemsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GemsRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.GemsRepositorySettings
 
 /**
@@ -11,8 +12,12 @@ import org.jfrog.artifactory.client.model.repository.settings.GemsRepositorySett
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class GemsRepositorySettingsImpl implements GemsRepositorySettings {
+class GemsRepositorySettingsImpl extends AbstractRepositorySettings implements GemsRepositorySettings {
     Boolean listRemoteFolderItems
+
+    public GemsRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.gems.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GenericRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GenericRepositorySettingsImpl.groovy
@@ -13,10 +13,12 @@ import org.jfrog.artifactory.client.model.repository.settings.GenericRepositoryS
  */
 @EqualsAndHashCode
 class GenericRepositorySettingsImpl extends AbstractRepositorySettings implements GenericRepositorySettings {
+    static String defaultLayout = "simple-default"
+
     Boolean listRemoteFolderItems
 
     public GenericRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.generic.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GenericRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GenericRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.GenericRepositorySettings
 
 /**
@@ -11,8 +12,12 @@ import org.jfrog.artifactory.client.model.repository.settings.GenericRepositoryS
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class GenericRepositorySettingsImpl implements GenericRepositorySettings {
+class GenericRepositorySettingsImpl extends AbstractRepositorySettings implements GenericRepositorySettings {
     Boolean listRemoteFolderItems
+
+    public GenericRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.generic.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GenericRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GenericRepositorySettingsImpl.groovy
@@ -16,6 +16,6 @@ class GenericRepositorySettingsImpl implements GenericRepositorySettings {
 
     @Override
     public PackageType getPackageType() {
-        return PackageTypeImpl.generic;
+        return PackageTypeImpl.generic
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GitLfsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GitLfsRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.GitLfsRepositorySettings
 
 /**
@@ -11,8 +12,12 @@ import org.jfrog.artifactory.client.model.repository.settings.GitLfsRepositorySe
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class GitLfsRepositorySettingsImpl implements GitLfsRepositorySettings {
+class GitLfsRepositorySettingsImpl extends AbstractRepositorySettings implements GitLfsRepositorySettings {
     Boolean listRemoteFolderItems
+
+    public GitLfsRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.gitlfs.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GitLfsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GitLfsRepositorySettingsImpl.groovy
@@ -13,10 +13,12 @@ import org.jfrog.artifactory.client.model.repository.settings.GitLfsRepositorySe
  */
 @EqualsAndHashCode
 class GitLfsRepositorySettingsImpl extends AbstractRepositorySettings implements GitLfsRepositorySettings {
+    static String defaultLayout = "simple-default"
+
     Boolean listRemoteFolderItems
 
     public GitLfsRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.gitlfs.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GradleRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GradleRepositorySettingsImpl.groovy
@@ -12,8 +12,18 @@ import org.jfrog.artifactory.client.model.repository.settings.GradleRepositorySe
  */
 @EqualsAndHashCode
 class GradleRepositorySettingsImpl extends MavenRepositorySettingsImpl implements GradleRepositorySettings {
+
+    GradleRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.gradle.layout
+    }
+
     @Override
     public PackageType getPackageType() {
         return PackageTypeImpl.gradle
+    }
+
+    @Override
+    public String getRepoLayout() {
+        return this.repoLayoutRef
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GradleRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GradleRepositorySettingsImpl.groovy
@@ -12,9 +12,10 @@ import org.jfrog.artifactory.client.model.repository.settings.GradleRepositorySe
  */
 @EqualsAndHashCode
 class GradleRepositorySettingsImpl extends MavenRepositorySettingsImpl implements GradleRepositorySettings {
+    static String defaultLayout = "gradle-default"
 
     GradleRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.gradle.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/IvyRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/IvyRepositorySettingsImpl.groovy
@@ -12,6 +12,11 @@ import org.jfrog.artifactory.client.model.repository.settings.IvyRepositorySetti
  */
 @EqualsAndHashCode
 class IvyRepositorySettingsImpl extends MavenRepositorySettingsImpl implements IvyRepositorySettings {
+
+    public IvyRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.ivy.layout
+    }
+
     @Override
     public PackageType getPackageType() {
         return PackageTypeImpl.ivy

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/IvyRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/IvyRepositorySettingsImpl.groovy
@@ -12,9 +12,10 @@ import org.jfrog.artifactory.client.model.repository.settings.IvyRepositorySetti
  */
 @EqualsAndHashCode
 class IvyRepositorySettingsImpl extends MavenRepositorySettingsImpl implements IvyRepositorySettings {
+    static String defaultLayout = "ivy-default"
 
     public IvyRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.ivy.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/MavenRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/MavenRepositorySettingsImpl.groovy
@@ -7,6 +7,7 @@ import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
 import org.jfrog.artifactory.client.model.impl.RemoteRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.SnapshotVersionBehaviorImpl
 import org.jfrog.artifactory.client.model.repository.PomCleanupPolicy
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.MavenRepositorySettings
 
 /**
@@ -15,7 +16,7 @@ import org.jfrog.artifactory.client.model.repository.settings.MavenRepositorySet
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class MavenRepositorySettingsImpl implements MavenRepositorySettings {
+class MavenRepositorySettingsImpl extends AbstractRepositorySettings implements MavenRepositorySettings {
     Integer maxUniqueSnapshots
     Boolean handleReleases
     Boolean handleSnapshots
@@ -29,6 +30,10 @@ class MavenRepositorySettingsImpl implements MavenRepositorySettings {
     Boolean rejectInvalidJars
     PomCleanupPolicy pomRepositoryReferencesCleanupPolicy
     String keyPair
+
+    public MavenRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.maven.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/MavenRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/MavenRepositorySettingsImpl.groovy
@@ -17,6 +17,8 @@ import org.jfrog.artifactory.client.model.repository.settings.MavenRepositorySet
  */
 @EqualsAndHashCode
 class MavenRepositorySettingsImpl extends AbstractRepositorySettings implements MavenRepositorySettings {
+    static String defaultLayout = "maven-2-default"
+
     Integer maxUniqueSnapshots
     Boolean handleReleases
     Boolean handleSnapshots
@@ -32,7 +34,7 @@ class MavenRepositorySettingsImpl extends AbstractRepositorySettings implements 
     String keyPair
 
     public MavenRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.maven.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NpmRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NpmRepositorySettingsImpl.groovy
@@ -13,13 +13,15 @@ import org.jfrog.artifactory.client.model.repository.settings.NpmRepositorySetti
  */
 @EqualsAndHashCode
 class NpmRepositorySettingsImpl extends AbstractRepositorySettings implements NpmRepositorySettings {
+    static String defaultLayout = "npm-default"
+
     Boolean listRemoteFolderItems
     Boolean externalDependenciesEnabled
     Collection<String> externalDependenciesPatterns
     String externalDependenciesRemoteRepo
 
     public NpmRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.npm.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NpmRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NpmRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.NpmRepositorySettings
 
 /**
@@ -11,11 +12,15 @@ import org.jfrog.artifactory.client.model.repository.settings.NpmRepositorySetti
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class NpmRepositorySettingsImpl implements NpmRepositorySettings {
+class NpmRepositorySettingsImpl extends AbstractRepositorySettings implements NpmRepositorySettings {
     Boolean listRemoteFolderItems
     Boolean externalDependenciesEnabled
     Collection<String> externalDependenciesPatterns
     String externalDependenciesRemoteRepo
+
+    public NpmRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.npm.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NugetRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NugetRepositorySettingsImpl.groovy
@@ -13,6 +13,8 @@ import org.jfrog.artifactory.client.model.repository.settings.NugetRepositorySet
  */
 @EqualsAndHashCode
 class NugetRepositorySettingsImpl extends AbstractRepositorySettings implements NugetRepositorySettings {
+    static String defaultLayout = "nuget-default"
+
     Integer maxUniqueSnapshots
     Boolean forceNugetAuthentication
     String feedContextPath
@@ -20,7 +22,7 @@ class NugetRepositorySettingsImpl extends AbstractRepositorySettings implements 
     Boolean listRemoteFolderItems
 
     public NugetRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.nuget.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NugetRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NugetRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.NugetRepositorySettings
 
 /**
@@ -11,12 +12,16 @@ import org.jfrog.artifactory.client.model.repository.settings.NugetRepositorySet
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class NugetRepositorySettingsImpl implements NugetRepositorySettings {
+class NugetRepositorySettingsImpl extends AbstractRepositorySettings implements NugetRepositorySettings {
     Integer maxUniqueSnapshots
     Boolean forceNugetAuthentication
     String feedContextPath
     String downloadContextPath
     Boolean listRemoteFolderItems
+
+    public NugetRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.nuget.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/OpkgRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/OpkgRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.OpkgRepositorySettings
 
 /**
@@ -11,8 +12,12 @@ import org.jfrog.artifactory.client.model.repository.settings.OpkgRepositorySett
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class OpkgRepositorySettingsImpl implements OpkgRepositorySettings {
+class OpkgRepositorySettingsImpl extends AbstractRepositorySettings implements OpkgRepositorySettings {
     Boolean listRemoteFolderItems
+
+    public OpkgRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.opkg.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/OpkgRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/OpkgRepositorySettingsImpl.groovy
@@ -13,10 +13,12 @@ import org.jfrog.artifactory.client.model.repository.settings.OpkgRepositorySett
  */
 @EqualsAndHashCode
 class OpkgRepositorySettingsImpl extends AbstractRepositorySettings implements OpkgRepositorySettings {
+    static String defaultLayout = "simple-default"
+
     Boolean listRemoteFolderItems
 
     public OpkgRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.opkg.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/P2RepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/P2RepositorySettingsImpl.groovy
@@ -12,6 +12,11 @@ import org.jfrog.artifactory.client.model.repository.settings.P2RepositorySettin
  */
 @EqualsAndHashCode
 class P2RepositorySettingsImpl extends MavenRepositorySettingsImpl implements P2RepositorySettings {
+
+    public P2RepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.p2.layout
+    }
+
     @Override
     public PackageType getPackageType() {
         return PackageTypeImpl.p2

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/P2RepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/P2RepositorySettingsImpl.groovy
@@ -12,9 +12,8 @@ import org.jfrog.artifactory.client.model.repository.settings.P2RepositorySettin
  */
 @EqualsAndHashCode
 class P2RepositorySettingsImpl extends MavenRepositorySettingsImpl implements P2RepositorySettings {
-
     public P2RepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.p2.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PuppetRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PuppetRepositorySettingsImpl.groovy
@@ -3,10 +3,15 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.PuppetRepositorySettings
 
 @EqualsAndHashCode
-class PuppetRepositorySettingsImpl implements PuppetRepositorySettings {
+class PuppetRepositorySettingsImpl extends AbstractRepositorySettings implements PuppetRepositorySettings {
+
+    public PuppetRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.puppet.layout
+    }
 
     @Override
     PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PuppetRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PuppetRepositorySettingsImpl.groovy
@@ -8,9 +8,10 @@ import org.jfrog.artifactory.client.model.repository.settings.PuppetRepositorySe
 
 @EqualsAndHashCode
 class PuppetRepositorySettingsImpl extends AbstractRepositorySettings implements PuppetRepositorySettings {
+    static String defaultLayout = "puppet-default"
 
     public PuppetRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.puppet.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PypiRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PypiRepositorySettingsImpl.groovy
@@ -13,10 +13,12 @@ import org.jfrog.artifactory.client.model.repository.settings.PypiRepositorySett
  */
 @EqualsAndHashCode
 class PypiRepositorySettingsImpl extends AbstractRepositorySettings implements PypiRepositorySettings {
+    static String defaultLayout = "simple-default"
+
     Boolean listRemoteFolderItems
 
     public PypiRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.pypi.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PypiRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PypiRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.PypiRepositorySettings
 
 /**
@@ -11,8 +12,12 @@ import org.jfrog.artifactory.client.model.repository.settings.PypiRepositorySett
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class PypiRepositorySettingsImpl implements PypiRepositorySettings {
+class PypiRepositorySettingsImpl extends AbstractRepositorySettings implements PypiRepositorySettings {
     Boolean listRemoteFolderItems
+
+    public PypiRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.pypi.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/RpmRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/RpmRepositorySettingsImpl.groovy
@@ -13,6 +13,8 @@ import org.jfrog.artifactory.client.model.repository.settings.RpmRepositorySetti
  */
 @EqualsAndHashCode
 class RpmRepositorySettingsImpl extends AbstractRepositorySettings implements RpmRepositorySettings {
+    static String defaultLayout = "simple-default"
+
     Integer yumRootDepth
     String groupFileNames
     Boolean calculateYumMetadata
@@ -20,7 +22,7 @@ class RpmRepositorySettingsImpl extends AbstractRepositorySettings implements Rp
     Boolean listRemoteFolderItems
 
     public RpmRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.rpm.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/RpmRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/RpmRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.RpmRepositorySettings
 
 /**
@@ -11,12 +12,16 @@ import org.jfrog.artifactory.client.model.repository.settings.RpmRepositorySetti
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class RpmRepositorySettingsImpl implements RpmRepositorySettings {
+class RpmRepositorySettingsImpl extends AbstractRepositorySettings implements RpmRepositorySettings {
     Integer yumRootDepth
     String groupFileNames
     Boolean calculateYumMetadata
     Boolean enableFileListsIndexing
     Boolean listRemoteFolderItems
+
+    public RpmRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.rpm.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/SbtRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/SbtRepositorySettingsImpl.groovy
@@ -12,6 +12,11 @@ import org.jfrog.artifactory.client.model.repository.settings.SbtRepositorySetti
  */
 @EqualsAndHashCode
 class SbtRepositorySettingsImpl extends MavenRepositorySettingsImpl implements SbtRepositorySettings {
+
+    public SbtRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.sbt.layout
+    }
+
     @Override
     public PackageType getPackageType() {
         return PackageTypeImpl.sbt

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/SbtRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/SbtRepositorySettingsImpl.groovy
@@ -12,9 +12,10 @@ import org.jfrog.artifactory.client.model.repository.settings.SbtRepositorySetti
  */
 @EqualsAndHashCode
 class SbtRepositorySettingsImpl extends MavenRepositorySettingsImpl implements SbtRepositorySettings {
+    static String defaultLayout = "sbt-default"
 
     public SbtRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.sbt.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VagrantRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VagrantRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.VagrantRepositorySettings
 
 /**
@@ -11,7 +12,12 @@ import org.jfrog.artifactory.client.model.repository.settings.VagrantRepositoryS
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class VagrantRepositorySettingsImpl implements VagrantRepositorySettings {
+class VagrantRepositorySettingsImpl extends AbstractRepositorySettings implements VagrantRepositorySettings {
+
+    public VagrantRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.vagrant.layout
+    }
+
     @Override
     public PackageType getPackageType() {
         return PackageTypeImpl.vagrant

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VagrantRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VagrantRepositorySettingsImpl.groovy
@@ -13,9 +13,10 @@ import org.jfrog.artifactory.client.model.repository.settings.VagrantRepositoryS
  */
 @EqualsAndHashCode
 class VagrantRepositorySettingsImpl extends AbstractRepositorySettings implements VagrantRepositorySettings {
+    static String defaultLayout = "simple-default"
 
     public VagrantRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.vagrant.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VcsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VcsRepositorySettingsImpl.groovy
@@ -15,6 +15,8 @@ import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsType
  */
 @EqualsAndHashCode
 class VcsRepositorySettingsImpl extends AbstractRepositorySettings implements VcsRepositorySettings {
+    static defaultLayout = "vcs-default"
+
     VcsGitProvider vcsGitProvider
     VcsType vcsType
     Integer maxUniqueSnapshots
@@ -22,7 +24,7 @@ class VcsRepositorySettingsImpl extends AbstractRepositorySettings implements Vc
     Boolean listRemoteFolderItems
 
     public VcsRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.vcs.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VcsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VcsRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.VcsRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsGitProvider
 import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsType
@@ -13,12 +14,16 @@ import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsType
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-class VcsRepositorySettingsImpl implements VcsRepositorySettings {
+class VcsRepositorySettingsImpl extends AbstractRepositorySettings implements VcsRepositorySettings {
     VcsGitProvider vcsGitProvider
     VcsType vcsType
     Integer maxUniqueSnapshots
     String vcsGitDownloadUrl
     Boolean listRemoteFolderItems
+
+    public VcsRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.vcs.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/YumRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/YumRepositorySettingsImpl.groovy
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.repository.settings.impl
 import groovy.transform.EqualsAndHashCode
 import org.jfrog.artifactory.client.model.PackageType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.RpmRepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.YumRepositorySettings
 
@@ -14,11 +15,15 @@ import org.jfrog.artifactory.client.model.repository.settings.YumRepositorySetti
  */
 @Deprecated
 @EqualsAndHashCode
-class YumRepositorySettingsImpl implements YumRepositorySettings {
+class YumRepositorySettingsImpl extends AbstractRepositorySettings implements YumRepositorySettings {
     Integer yumRootDepth
     String groupFileNames
     Boolean calculateYumMetadata
     Boolean listRemoteFolderItems
+
+    public YumRepositorySettingsImpl() {
+        this.repoLayoutRef = PackageTypeImpl.yum.layout
+    }
 
     @Override
     public PackageType getPackageType() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/YumRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/YumRepositorySettingsImpl.groovy
@@ -16,13 +16,15 @@ import org.jfrog.artifactory.client.model.repository.settings.YumRepositorySetti
 @Deprecated
 @EqualsAndHashCode
 class YumRepositorySettingsImpl extends AbstractRepositorySettings implements YumRepositorySettings {
+    static String defaultLayout = "simple-default"
+
     Integer yumRootDepth
     String groupFileNames
     Boolean calculateYumMetadata
     Boolean listRemoteFolderItems
 
     public YumRepositorySettingsImpl() {
-        this.repoLayoutRef = PackageTypeImpl.yum.layout
+        this.repoLayoutRef = defaultLayout
     }
 
     @Override

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/CustomPackageTypeImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/CustomPackageTypeImpl.java
@@ -3,7 +3,6 @@ package org.jfrog.artifactory.client.model.impl;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import org.jfrog.artifactory.client.model.PackageType;
-import org.jfrog.artifactory.client.model.Repository;
 
 public class CustomPackageTypeImpl implements PackageType {
 
@@ -22,10 +21,5 @@ public class CustomPackageTypeImpl implements PackageType {
     @Override
     public boolean isCustom() {
         return true;
-    }
-
-    @Override
-    public String getLayout() {
-        return Repository.MAVEN_2_REPO_LAYOUT;
     }
 }

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/CustomPackageTypeImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/CustomPackageTypeImpl.java
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.model.impl;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import org.jfrog.artifactory.client.model.PackageType;
+import org.jfrog.artifactory.client.model.Repository;
 
 public class CustomPackageTypeImpl implements PackageType {
 
@@ -21,5 +22,10 @@ public class CustomPackageTypeImpl implements PackageType {
     @Override
     public boolean isCustom() {
         return true;
+    }
+
+    @Override
+    public String getLayout() {
+        return Repository.MAVEN_2_REPO_LAYOUT;
     }
 }

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/PackageTypeImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/PackageTypeImpl.java
@@ -3,44 +3,34 @@ package org.jfrog.artifactory.client.model.impl;
 import org.jfrog.artifactory.client.model.PackageType;
 
 public enum PackageTypeImpl implements PackageType {
-  bower("bower-default"),
-  cocoapods("simple-default"),
-  debian("simple-default"),
-  distribution("simple-default"),
-  docker("simple-default"),
-  gems("simple-default"),
-  generic("simple-default"),
-  gitlfs("simple-default"),
-  gradle("gradle-default"),
-  ivy("ivy-default"),
-  maven("maven-2-default"),
-  npm("npm-default"),
-  nuget("nuget-default"),
-  opkg("simple-default"),
-  p2("simple-default"),
-  pypi("simple-default"),
-  sbt("sbt-default"),
-  vagrant("simple-default"),
-  vcs("vcs-default"),
-  yum("simple-default"),
-  rpm("simple-default"),
-  composer("composer-default"),
-  conan("conan-default"),
-  chef("simple-default"),
-  puppet("puppet-default");
+    bower,
+    cocoapods,
+    debian,
+    distribution,
+    docker,
+    gems,
+    generic,
+    gitlfs,
+    gradle,
+    ivy,
+    maven,
+    npm,
+    nuget,
+    opkg,
+    p2,
+    pypi,
+    sbt,
+    vagrant,
+    vcs,
+    yum,
+    rpm,
+    composer,
+    conan,
+    chef,
+    puppet;
 
-  private final String layout;
-
-  PackageTypeImpl(String layout) {
-    this.layout = layout;
-  }
-
-  @Override
-  public boolean isCustom() {
-    return false;
-  }
-
-  public String getLayout() {
-    return layout;
-  }
+    @Override
+    public boolean isCustom() {
+        return false;
+    }
 }

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/PackageTypeImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/PackageTypeImpl.java
@@ -40,7 +40,6 @@ public enum PackageTypeImpl implements PackageType {
     return false;
   }
 
-  @Override
   public String getLayout() {
     return layout;
   }

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/PackageTypeImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/PackageTypeImpl.java
@@ -3,11 +3,45 @@ package org.jfrog.artifactory.client.model.impl;
 import org.jfrog.artifactory.client.model.PackageType;
 
 public enum PackageTypeImpl implements PackageType {
-  bower, cocoapods, debian, distribution, docker, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, opkg, p2,
-  pypi, sbt, vagrant, vcs, yum, rpm, composer, conan, chef, puppet;
+  bower("bower-default"),
+  cocoapods("simple-default"),
+  debian("simple-default"),
+  distribution("simple-default"),
+  docker("simple-default"),
+  gems("simple-default"),
+  generic("simple-default"),
+  gitlfs("simple-default"),
+  gradle("gradle-default"),
+  ivy("ivy-default"),
+  maven("maven-2-default"),
+  npm("npm-default"),
+  nuget("nuget-default"),
+  opkg("simple-default"),
+  p2("simple-default"),
+  pypi("simple-default"),
+  sbt("sbt-default"),
+  vagrant("simple-default"),
+  vcs("vcs-default"),
+  yum("simple-default"),
+  rpm("simple-default"),
+  composer("composer-default"),
+  conan("conan-default"),
+  chef("simple-default"),
+  puppet("puppet-default");
+
+  private final String layout;
+
+  PackageTypeImpl(String layout) {
+    this.layout = layout;
+  }
 
   @Override
   public boolean isCustom() {
     return false;
+  }
+
+  @Override
+  public String getLayout() {
+    return layout;
   }
 }

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/VirtualRepositoryImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/VirtualRepositoryImpl.java
@@ -17,10 +17,10 @@ public class VirtualRepositoryImpl extends RepositoryBase implements VirtualRepo
     private boolean artifactoryRequestsCanRetrieveRemoteArtifacts;
     private String deploymentRepo;
 
-    private VirtualRepositoryImpl() {
+    VirtualRepositoryImpl() {
     }
 
-    private VirtualRepositoryImpl(String key, RepositorySettings settings,
+    VirtualRepositoryImpl(String key, RepositorySettings settings,
         String description, String excludesPattern, String includesPattern, String notes,
         boolean artifactoryRequestsCanRetrieveRemoteArtifacts, Collection<String> repositories,
         String repoLayoutRef, String deploymentRepo, Map<String, Object> customProperties) {

--- a/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/CustomRepositorySettingsImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/CustomRepositorySettingsImpl.java
@@ -2,17 +2,17 @@ package org.jfrog.artifactory.client.model.repository.settings.impl;
 
 import org.jfrog.artifactory.client.model.PackageType;
 import org.jfrog.artifactory.client.model.impl.CustomPackageTypeImpl;
-import org.jfrog.artifactory.client.model.impl.PackageTypeImpl;
 import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings;
 import org.jfrog.artifactory.client.model.repository.settings.CustomRepositorySettings;
 
 public class CustomRepositorySettingsImpl extends AbstractRepositorySettings implements CustomRepositorySettings {
+    public static String defaultLayout = "maven-2-default";
 
     private PackageType packageType;
 
     public CustomRepositorySettingsImpl(CustomPackageTypeImpl packageType) {
         this.packageType = packageType;
-        this.repoLayoutRef = PackageTypeImpl.maven.getLayout();
+        this.repoLayoutRef = defaultLayout;
     }
 
     @Override

--- a/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/CustomRepositorySettingsImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/CustomRepositorySettingsImpl.java
@@ -2,14 +2,17 @@ package org.jfrog.artifactory.client.model.repository.settings.impl;
 
 import org.jfrog.artifactory.client.model.PackageType;
 import org.jfrog.artifactory.client.model.impl.CustomPackageTypeImpl;
+import org.jfrog.artifactory.client.model.impl.PackageTypeImpl;
+import org.jfrog.artifactory.client.model.repository.settings.AbstractRepositorySettings;
 import org.jfrog.artifactory.client.model.repository.settings.CustomRepositorySettings;
 
-public class CustomRepositorySettingsImpl implements CustomRepositorySettings {
+public class CustomRepositorySettingsImpl extends AbstractRepositorySettings implements CustomRepositorySettings {
 
     private PackageType packageType;
 
     public CustomRepositorySettingsImpl(CustomPackageTypeImpl packageType) {
         this.packageType = packageType;
+        this.repoLayoutRef = PackageTypeImpl.maven.getLayout();
     }
 
     @Override

--- a/services/src/test/groovy/org/jfrog/artifactory/client/BaseRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/BaseRepositoryTests.groovy
@@ -5,10 +5,11 @@ import org.hamcrest.Matcher
 import org.hamcrest.StringDescription
 import org.jfrog.artifactory.client.model.ContentSync
 import org.jfrog.artifactory.client.model.Repository
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.ContentSyncImpl
+import org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl
 import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.XraySettings
-import org.jfrog.artifactory.client.model.repository.settings.impl.GenericRepositorySettingsImpl
 import org.jfrog.artifactory.client.model.xray.settings.impl.XraySettingsImpl
 import org.testng.annotations.AfterMethod
 import org.testng.annotations.BeforeMethod
@@ -34,15 +35,16 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
     protected Repository remoteRepo
     protected Repository virtualRepo
 
-    protected RepositorySettings settings
     protected XraySettings xraySettings
     protected Map<String, Object> customProperties
+
+    abstract RepositorySettings getRepositorySettings(RepositoryType repositoryType)
 
     @BeforeMethod
     protected void setUp() {
         if (prepareGenericRepo) {
-            RepositorySettings genericSettings = new GenericRepositorySettingsImpl()
-            genericSettings.repoLayout = nextRepoLayout()
+            RepositorySettings settings = getRepositorySettings(RepositoryTypeImpl.LOCAL)
+            settings?.repoLayout = nextRepoLayout()
 
             XraySettings genericXraySettings = new XraySettingsImpl();
             genericRepo = artifactory.repositories().builders().localRepositoryBuilder()
@@ -54,12 +56,13 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
                     .excludesPattern("org/${rnd.nextInt()}/**")
                     .includesPattern("org/${rnd.nextInt()}/**")
                     .propertySets(Collections.emptyList()) // no property sets configured
-                    .repositorySettings(genericSettings)
+                    .repositorySettings(settings)
                     .xraySettings(genericXraySettings)
                     .customProperties(new HashMap<String, Object>())
                     .build()
         }
         if (prepareLocalRepo) {
+            RepositorySettings settings = getRepositorySettings()
             settings?.repoLayout = nextRepoLayout()
             localRepo = artifactory.repositories().builders().localRepositoryBuilder()
                 .key("cutsman-repo_${rnd.nextInt()}")
@@ -77,6 +80,7 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
         }
 
         if(prepareRemoteRepo) {
+            RepositorySettings settings = getRepositorySettings()
             settings?.repoLayout = nextRepoLayout()
             ContentSync contentSync = new ContentSyncImpl();
             remoteRepo = artifactory.repositories().builders().remoteRepositoryBuilder()
@@ -117,6 +121,7 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
         }
 
         if(prepareVirtualRepo) {
+            RepositorySettings settings = getRepositorySettings()
             settings?.repoLayout = nextRepoLayout()
             artifactory.repositories().create(0, genericRepo)
             def repos = new ArrayList<String>()
@@ -148,16 +153,16 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
 
     private String nextRepoLayout() {
         def layouts = [
-            //'bower-default',
-            //'gradle-default',
-            //'ivy-default',
-            //'maven-1-default',
-            'maven-2-default'
-            //'npm-default',
-            //'nuget-default',
-            //'sbt-default',
-            //'simple-default',
-            //'vcs-default'
+            'bower-default',
+            'gradle-default',
+            'ivy-default',
+            'maven-1-default',
+            'maven-2-default',
+            'npm-default',
+            'nuget-default',
+            'sbt-default',
+            'simple-default',
+            'vcs-default'
         ]
 
         layouts.getAt(rnd.nextInt(layouts.size()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/BaseRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/BaseRepositoryTests.groovy
@@ -41,7 +41,9 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
     @BeforeMethod
     protected void setUp() {
         if (prepareGenericRepo) {
-            RepositorySettings genericSettings = new GenericRepositorySettingsImpl();
+            RepositorySettings genericSettings = new GenericRepositorySettingsImpl()
+            genericSettings.repoLayout = nextRepoLayout()
+
             XraySettings genericXraySettings = new XraySettingsImpl();
             genericRepo = artifactory.repositories().builders().localRepositoryBuilder()
                     .key("cutsman-repo_${rnd.nextInt()}")
@@ -52,13 +54,13 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
                     .excludesPattern("org/${rnd.nextInt()}/**")
                     .includesPattern("org/${rnd.nextInt()}/**")
                     .propertySets(Collections.emptyList()) // no property sets configured
-                    .repoLayoutRef(nextRepoLayout())
                     .repositorySettings(genericSettings)
                     .xraySettings(genericXraySettings)
                     .customProperties(new HashMap<String, Object>())
-                    .build();
+                    .build()
         }
         if (prepareLocalRepo) {
+            settings?.repoLayout = nextRepoLayout()
             localRepo = artifactory.repositories().builders().localRepositoryBuilder()
                 .key("cutsman-repo_${rnd.nextInt()}")
                 .description("description_${rnd.nextInt()}")
@@ -68,14 +70,14 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
                 .excludesPattern("org/${rnd.nextInt()}/**")
                 .includesPattern("org/${rnd.nextInt()}/**")
                 .propertySets(Collections.emptyList()) // no property sets configured
-                .repoLayoutRef(nextRepoLayout())
                 .repositorySettings(settings)
                 .xraySettings(xraySettings)
                 .customProperties(customProperties)
-                .build();
+                .build()
         }
 
         if(prepareRemoteRepo) {
+            settings?.repoLayout = nextRepoLayout()
             ContentSync contentSync = new ContentSyncImpl();
             remoteRepo = artifactory.repositories().builders().remoteRepositoryBuilder()
                 .key("cutsman-repo_${rnd.nextInt()}")
@@ -97,7 +99,6 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
                 .password("password_${rnd.nextInt()}")
                 .propertySets(Collections.emptyList()) // no property sets configured
                 // .proxy("") // no proxy configured
-                .repoLayoutRef(nextRepoLayout())
                 .retrievalCachePeriodSecs(rnd.nextInt())
                 .shareConfiguration(rnd.nextBoolean())
                 .socketTimeoutMillis(rnd.nextInt())
@@ -116,6 +117,7 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
         }
 
         if(prepareVirtualRepo) {
+            settings?.repoLayout = nextRepoLayout()
             artifactory.repositories().create(0, genericRepo)
             def repos = new ArrayList<String>()
             repos.add(genericRepo.getKey())
@@ -127,7 +129,6 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
                 .artifactoryRequestsCanRetrieveRemoteArtifacts(rnd.nextBoolean())
                 .excludesPattern("org/${rnd.nextInt()}/**")
                 .includesPattern("org/${rnd.nextInt()}/**")
-                .repoLayoutRef(nextRepoLayout())
                 .repositories(repos)
                 .repositorySettings(settings)
                 .customProperties(customProperties)

--- a/services/src/test/groovy/org/jfrog/artifactory/client/BowerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/BowerPackageTypeRepositoryTests.groovy
@@ -1,6 +1,8 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.BowerRepositorySettingsImpl
 import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsGitProvider
 import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsType
@@ -14,9 +16,9 @@ import org.testng.annotations.Test
  */
 public class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new BowerRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new BowerRepositorySettingsImpl()
 
         settings.with {
             // remote
@@ -34,20 +36,26 @@ public class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
             // externalDependenciesRemoteRepo
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "bowerPackageTypeRepo")
     public void testBowerLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots())) // always in resp payload
             assertThat(bowerRegistryUrl, CoreMatchers.nullValue())
             assertThat(vcsGitDownloadUrl, CoreMatchers.nullValue())
             assertThat(vcsGitProvider, CoreMatchers.nullValue())
@@ -63,18 +71,19 @@ public class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "bowerPackageTypeRepo")
     public void testBowerRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // remote
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))
-            assertThat(bowerRegistryUrl, CoreMatchers.is(settings.getBowerRegistryUrl()))
-            assertThat(vcsGitDownloadUrl, CoreMatchers.is(settings.getVcsGitDownloadUrl()))
-            assertThat(vcsGitProvider, CoreMatchers.is(settings.getVcsGitProvider()))
-            assertThat(vcsType, CoreMatchers.is(settings.getVcsType()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
+            assertThat(bowerRegistryUrl, CoreMatchers.is(expectedSettings.getBowerRegistryUrl()))
+            assertThat(vcsGitDownloadUrl, CoreMatchers.is(expectedSettings.getVcsGitDownloadUrl()))
+            assertThat(vcsGitProvider, CoreMatchers.is(expectedSettings.getVcsGitProvider()))
+            assertThat(vcsType, CoreMatchers.is(expectedSettings.getVcsType()))
 
             // virtual
             assertThat(externalDependenciesEnabled, CoreMatchers.nullValue())
@@ -86,10 +95,11 @@ public class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "bowerPackageTypeRepo")
     public void testBowerVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
@@ -100,9 +110,9 @@ public class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(vcsType, CoreMatchers.nullValue())
 
             // virtual
-            assertThat(externalDependenciesEnabled, CoreMatchers.is(settings.getExternalDependenciesEnabled()))
-            assertThat(externalDependenciesPatterns, CoreMatchers.is(settings.getExternalDependenciesPatterns()))
-            assertThat(externalDependenciesRemoteRepo, CoreMatchers.is(settings.getExternalDependenciesRemoteRepo()))
+            assertThat(externalDependenciesEnabled, CoreMatchers.is(expectedSettings.getExternalDependenciesEnabled()))
+            assertThat(externalDependenciesPatterns, CoreMatchers.is(expectedSettings.getExternalDependenciesPatterns()))
+            assertThat(externalDependenciesRemoteRepo, CoreMatchers.is(expectedSettings.getExternalDependenciesRemoteRepo()))
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ChefPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ChefPackageTypeRepositoryTests.groovy
@@ -1,6 +1,8 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.ChefRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -10,39 +12,46 @@ import org.testng.annotations.Test
  */
 public class ChefPackageTypeRepositoryTests extends BaseRepositoryTests {
 
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        return new ChefRepositorySettingsImpl()
+    }
+
     @BeforeMethod
     protected void setUp() {
-        settings = new ChefRepositorySettingsImpl()
         super.setUp()
     }
 
     @Test(groups = "chefPackageTypeRepo")
     public void testChefLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 
     @Test(groups = "chefPackageTypeRepo")
     public void testChefRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 
     @Test(groups = "chefPackageTypeRepo")
     public void testChefVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/CocoaPodsPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/CocoaPodsPackageTypeRepositoryTests.groovy
@@ -2,6 +2,7 @@ package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
 import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.CocoaPodsRepositorySettingsImpl
 import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsGitProvider
 import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsType
@@ -15,9 +16,9 @@ import org.testng.annotations.Test
  */
 public class CocoaPodsPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new CocoaPodsRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new CocoaPodsRepositorySettingsImpl()
 
         settings.with {
             // remote
@@ -29,6 +30,11 @@ public class CocoaPodsPackageTypeRepositoryTests extends BaseRepositoryTests {
             vcsType = VcsType.values()[rnd.nextInt(VcsType.values().length)]
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         // only local and remote repository supported
         prepareVirtualRepo = false
 
@@ -38,14 +44,15 @@ public class CocoaPodsPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "cocoapodsPackageTypeRepo")
     public void testCocoaPodsLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots())) // always in resp payload
             assertThat(podsSpecsRepoUrl, CoreMatchers.nullValue())
             assertThat(vcsGitDownloadUrl, CoreMatchers.nullValue())
             assertThat(vcsGitProvider, CoreMatchers.nullValue())
@@ -56,18 +63,19 @@ public class CocoaPodsPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "cocoapodsPackageTypeRepo")
     public void testCocoaPodsRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // remote
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))
-            assertThat(podsSpecsRepoUrl, CoreMatchers.is(settings.getPodsSpecsRepoUrl()))
-            assertThat(vcsGitDownloadUrl, CoreMatchers.is(settings.getVcsGitDownloadUrl()))
-            assertThat(vcsGitProvider, CoreMatchers.is(settings.getVcsGitProvider()))
-            assertThat(vcsType, CoreMatchers.is(settings.getVcsType()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
+            assertThat(podsSpecsRepoUrl, CoreMatchers.is(expectedSettings.getPodsSpecsRepoUrl()))
+            assertThat(vcsGitDownloadUrl, CoreMatchers.is(expectedSettings.getVcsGitDownloadUrl()))
+            assertThat(vcsGitProvider, CoreMatchers.is(expectedSettings.getVcsGitProvider()))
+            assertThat(vcsType, CoreMatchers.is(expectedSettings.getVcsType()))
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ComposerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ComposerPackageTypeRepositoryTests.groovy
@@ -1,6 +1,8 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.ComposerRepositorySettingsImpl
 import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsGitProvider
 import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsType
@@ -12,74 +14,82 @@ import org.testng.annotations.Test
  */
 public class ComposerPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-  @BeforeMethod
-  protected void setUp() {
-    settings = new ComposerRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new ComposerRepositorySettingsImpl()
 
-    settings.with {
-      // remote
-      listRemoteFolderItems = rnd.nextBoolean()
-      maxUniqueSnapshots = rnd.nextInt()
-      composerRegistryUrl = "http://jfrog.com/${rnd.nextInt()}"
-      vcsGitDownloadUrl = "http://jfrog.com/${rnd.nextInt()}"
-      vcsGitProvider = VcsGitProvider.CUSTOM
-      vcsType = VcsType.values()[rnd.nextInt(VcsType.values().length)]
+        settings.with {
+            // remote
+            listRemoteFolderItems = rnd.nextBoolean()
+            maxUniqueSnapshots = rnd.nextInt()
+            composerRegistryUrl = "http://jfrog.com/${rnd.nextInt()}"
+            vcsGitDownloadUrl = "http://jfrog.com/${rnd.nextInt()}"
+            vcsGitProvider = VcsGitProvider.CUSTOM
+            vcsType = VcsType.values()[rnd.nextInt(VcsType.values().length)]
+        }
+
+        return settings
     }
 
-    super.setUp()
-  }
-
-  @Test(groups = "composerPackageTypeRepo")
-  public void testComposerLocalRepo() {
-    artifactory.repositories().create(0, localRepo)
-
-    def resp = artifactory.repository(localRepo.getKey()).get()
-    resp.getRepositorySettings().with {
-      assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
-
-      // remote
-      assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
-      assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots())) // always in resp payload
-      assertThat(composerRegistryUrl, CoreMatchers.nullValue())
-      assertThat(vcsGitDownloadUrl, CoreMatchers.nullValue())
-      assertThat(vcsGitProvider, CoreMatchers.nullValue())
-      assertThat(vcsType, CoreMatchers.nullValue())
+    @BeforeMethod
+    protected void setUp() {
+        super.setUp()
     }
-  }
 
-  @Test(groups = "composerPackageTypeRepo")
-  public void testComposerRemoteRepo() {
-    artifactory.repositories().create(0, remoteRepo)
+    @Test(groups = "composerPackageTypeRepo")
+    public void testComposerLocalRepo() {
+        artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
-    def resp = artifactory.repository(remoteRepo.getKey()).get()
-    resp.getRepositorySettings().with {
-      assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+        def resp = artifactory.repository(localRepo.getKey()).get()
+        resp.getRepositorySettings().with {
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
-      // remote
-      assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
-      assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))
-      assertThat(composerRegistryUrl, CoreMatchers.is(settings.getComposerRegistryUrl()))
-      assertThat(vcsGitDownloadUrl, CoreMatchers.is(settings.getVcsGitDownloadUrl()))
-      assertThat(vcsGitProvider, CoreMatchers.is(settings.getVcsGitProvider()))
-      assertThat(vcsType, CoreMatchers.is(settings.getVcsType()))
+            // remote
+            assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots())) // always in resp payload
+            assertThat(composerRegistryUrl, CoreMatchers.nullValue())
+            assertThat(vcsGitDownloadUrl, CoreMatchers.nullValue())
+            assertThat(vcsGitProvider, CoreMatchers.nullValue())
+            assertThat(vcsType, CoreMatchers.nullValue())
+        }
     }
-  }
 
-  @Test(groups = "composerPackageTypeRepo")
-  public void testComposerVirtualRepo() {
-    artifactory.repositories().create(0, virtualRepo)
+    @Test(groups = "composerPackageTypeRepo")
+    public void testComposerRemoteRepo() {
+        artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
-    def resp = artifactory.repository(virtualRepo.getKey()).get()
-    resp.getRepositorySettings().with {
-      assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+        def resp = artifactory.repository(remoteRepo.getKey()).get()
+        resp.getRepositorySettings().with {
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
-      // remote
-      assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
-      assertThat(maxUniqueSnapshots, CoreMatchers.nullValue())
-      assertThat(composerRegistryUrl, CoreMatchers.nullValue())
-      assertThat(vcsGitDownloadUrl, CoreMatchers.nullValue())
-      assertThat(vcsGitProvider, CoreMatchers.nullValue())
-      assertThat(vcsType, CoreMatchers.nullValue())
+            // remote
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
+            assertThat(composerRegistryUrl, CoreMatchers.is(expectedSettings.getComposerRegistryUrl()))
+            assertThat(vcsGitDownloadUrl, CoreMatchers.is(expectedSettings.getVcsGitDownloadUrl()))
+            assertThat(vcsGitProvider, CoreMatchers.is(expectedSettings.getVcsGitProvider()))
+            assertThat(vcsType, CoreMatchers.is(expectedSettings.getVcsType()))
+        }
     }
-  }
+
+    @Test(groups = "composerPackageTypeRepo")
+    public void testComposerVirtualRepo() {
+        artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
+
+        def resp = artifactory.repository(virtualRepo.getKey()).get()
+        resp.getRepositorySettings().with {
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+
+            // remote
+            assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
+            assertThat(maxUniqueSnapshots, CoreMatchers.nullValue())
+            assertThat(composerRegistryUrl, CoreMatchers.nullValue())
+            assertThat(vcsGitDownloadUrl, CoreMatchers.nullValue())
+            assertThat(vcsGitProvider, CoreMatchers.nullValue())
+            assertThat(vcsType, CoreMatchers.nullValue())
+        }
+    }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ConanPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ConanPackageTypeRepositoryTests.groovy
@@ -1,6 +1,8 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.ConanRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -9,39 +11,46 @@ import org.testng.annotations.Test
  * Test that client correctly sends and receives repository configuration with `conan` package type
  */
 public class ConanPackageTypeRepositoryTests extends BaseRepositoryTests {
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        return new ConanRepositorySettingsImpl()
+    }
+
     @BeforeMethod
     protected void setUp() {
-        settings = new ConanRepositorySettingsImpl()
         super.setUp()
     }
 
     @Test(groups = "conanPackageTypeRepo")
     public void testConanLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 
     @Test(groups = "conanPackageTypeRepo")
     public void testConanRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 
     @Test(groups = "conanPackageTypeRepo")
     public void testConanVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/CustomPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/CustomPackageTypeRepositoryTests.groovy
@@ -1,8 +1,10 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.CustomPackageTypeImpl
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.CustomRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -14,23 +16,26 @@ class CustomPackageTypeRepositoryTests extends BaseRepositoryTests {
     private boolean someListRemoteFolderItems
     private int someYumRootDepth
 
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        CustomPackageTypeImpl customPackageType = new CustomPackageTypeImpl("rpm")
+        return new CustomRepositorySettingsImpl(customPackageType)
+    }
+
     @BeforeMethod
     protected void setUp() {
-        CustomPackageTypeImpl customPackageType = new CustomPackageTypeImpl("rpm")
-        settings = new CustomRepositorySettingsImpl(customPackageType)
-
         someCalculateYumMetadata = true
         someGroupFileNames = "groups.xml"
         someListRemoteFolderItems = true
         someYumRootDepth = 0
 
         customProperties = [
-            "calculateYumMetadata" : someCalculateYumMetadata,
-            "groupFileNames" : someGroupFileNames ,
-            "yumRootDepth" : someYumRootDepth,
+                "calculateYumMetadata" : someCalculateYumMetadata,
+                "groupFileNames"       : someGroupFileNames,
+                "yumRootDepth"         : someYumRootDepth,
 
-            // remote
-            "listRemoteFolderItems" : someListRemoteFolderItems
+                // remote
+                "listRemoteFolderItems": someListRemoteFolderItems
         ]
         super.setUp()
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/CustomPropertiesRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/CustomPropertiesRepositoryTests.groovy
@@ -1,6 +1,8 @@
 package org.jfrog.artifactory.client
 
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
@@ -10,10 +12,15 @@ import static org.testng.Assert.assertTrue
 
 class CustomPropertiesRepositoryTests extends BaseRepositoryTests {
 
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        return null
+    }
+
     @BeforeMethod
     protected void setUp() {
         customProperties = [
-            "enableComposerSupport" : true
+                "enableComposerSupport": true
         ]
         super.setUp()
     }
@@ -48,7 +55,7 @@ class CustomPropertiesRepositoryTests extends BaseRepositoryTests {
     }
 
     @Test(groups = "customProperties")
-     void testRemoteRepo() {
+    void testRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
         assertTrue(curl(LIST_PATH).contains(remoteRepo.getKey()))
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/DebianPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/DebianPackageTypeRepositoryTests.groovy
@@ -2,6 +2,7 @@ package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
 import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.DebianRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -13,9 +14,9 @@ import org.testng.annotations.Test
  */
 public class DebianPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new DebianRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new DebianRepositorySettingsImpl()
 
         settings.with {
             // local
@@ -25,6 +26,11 @@ public class DebianPackageTypeRepositoryTests extends BaseRepositoryTests {
             listRemoteFolderItems = rnd.nextBoolean()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         // only local and remote repository supported
         prepareVirtualRepo = false
 
@@ -34,13 +40,14 @@ public class DebianPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "debianPackageTypeRepo")
     public void testDebianLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(debianTrivialLayout, CoreMatchers.is(settings.getDebianTrivialLayout()))
+            assertThat(debianTrivialLayout, CoreMatchers.is(expectedSettings.getDebianTrivialLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(CoreMatchers.nullValue()))
@@ -50,16 +57,17 @@ public class DebianPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "debianPackageTypeRepo")
     public void testDebianRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(debianTrivialLayout, CoreMatchers.is(Boolean.FALSE)) // always in resp payload
 
             // remote
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/DockerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/DockerPackageTypeRepositoryTests.groovy
@@ -1,7 +1,8 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.docker.DockerApiVersion
 import org.jfrog.artifactory.client.model.repository.settings.impl.DockerRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
@@ -9,14 +10,14 @@ import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `docker` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class DockerPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new DockerRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new DockerRepositorySettingsImpl()
 
         settings.with {
             // local
@@ -27,19 +28,25 @@ public class DockerPackageTypeRepositoryTests extends BaseRepositoryTests {
             listRemoteFolderItems = rnd.nextBoolean()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "dockerPackageTypeRepo")
     public void testDockerLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(dockerApiVersion, CoreMatchers.is(settings.getDockerApiVersion()))
+            assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion()))
 
             // remote
             assertThat(enableTokenAuthentication, CoreMatchers.is(CoreMatchers.nullValue()))
@@ -50,30 +57,32 @@ public class DockerPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "dockerPackageTypeRepo")
     public void testDockerRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(dockerApiVersion, CoreMatchers.is(settings.getDockerApiVersion())) // always in resp payload
+            assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion())) // always in resp payload
 
             // remote
-            assertThat(enableTokenAuthentication, CoreMatchers.is(settings.getEnableTokenAuthentication()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(enableTokenAuthentication, CoreMatchers.is(expectedSettings.getEnableTokenAuthentication()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
 
     @Test(groups = "dockerPackageTypeRepo")
     public void testDockerVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(dockerApiVersion, CoreMatchers.is(settings.getDockerApiVersion()))
+            assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion()))
 
             // remote
             assertThat(enableTokenAuthentication, CoreMatchers.is(CoreMatchers.nullValue()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GemsPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GemsPackageTypeRepositoryTests.groovy
@@ -1,37 +1,44 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.GemsRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `gems` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class GemsPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new GemsRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new GemsRepositorySettingsImpl()
 
         settings.with {
             // remote
             listRemoteFolderItems = rnd.nextBoolean()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "gemsPackageTypeRepo")
     public void testGemsLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -39,21 +46,23 @@ public class GemsPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "gemsPackageTypeRepo")
     public void testGemsRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
 
     @Test(groups = "gemsPackageTypeRepo")
     public void testGemsVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GeneralRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GeneralRepositoryTests.groovy
@@ -1,7 +1,9 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.GenericRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -15,9 +17,13 @@ import static org.testng.Assert.*
  */
 public class GeneralRepositoryTests extends BaseRepositoryTests {
 
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        return new GenericRepositorySettingsImpl()
+    }
+
     @BeforeMethod
     protected void setUp() {
-        settings = new GenericRepositorySettingsImpl()
         super.setUp()
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GeneralRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GeneralRepositoryTests.groovy
@@ -1,8 +1,9 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
 import org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.impl.GenericRepositorySettingsImpl
+import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 import static org.testng.Assert.*
@@ -13,6 +14,12 @@ import static org.testng.Assert.*
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class GeneralRepositoryTests extends BaseRepositoryTests {
+
+    @BeforeMethod
+    protected void setUp() {
+        settings = new GenericRepositorySettingsImpl()
+        super.setUp()
+    }
 
     @Test(groups = "generalRepo")
     public void testLocalRepo() {

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GenericPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GenericPackageTypeRepositoryTests.groovy
@@ -1,37 +1,44 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.GenericRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `generic` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class GenericPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new GenericRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new GenericRepositorySettingsImpl()
 
         settings.with {
             // remote
             listRemoteFolderItems = rnd.nextBoolean()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "genericPackageTypeRepo")
     public void testGenericLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -39,21 +46,23 @@ public class GenericPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "genericPackageTypeRepo")
     public void testGenericRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
 
     @Test(groups = "genericPackageTypeRepo")
     public void testGenericVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GitLfsPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GitLfsPackageTypeRepositoryTests.groovy
@@ -1,37 +1,44 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.GitLfsRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `gitlfs` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class GitLfsPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new GitLfsRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new GitLfsRepositorySettingsImpl()
 
         settings.with {
             // remote
             listRemoteFolderItems = rnd.nextBoolean()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "gitlfsPackageTypeRepo")
     public void testGitLfsLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -39,21 +46,23 @@ public class GitLfsPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "gitlfsPackageTypeRepo")
     public void testGitLfsRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
 
     @Test(groups = "gitlfsPackageTypeRepo")
     public void testGitLfsVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GradlePackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GradlePackageTypeRepositoryTests.groovy
@@ -1,25 +1,26 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.LocalRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.RemoteRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.SnapshotVersionBehaviorImpl
 import org.jfrog.artifactory.client.model.repository.PomCleanupPolicy
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.GradleRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `gradle` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new GradleRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new GradleRepositorySettingsImpl()
 
         settings.with {
             // local
@@ -34,7 +35,7 @@ public class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
             fetchJarsEagerly = rnd.nextBoolean()
             fetchSourcesEagerly = rnd.nextBoolean()
             listRemoteFolderItems = rnd.nextBoolean()
-            rejectInvalidJars= rnd.nextBoolean()
+            rejectInvalidJars = rnd.nextBoolean()
             remoteRepoChecksumPolicyType = RemoteRepoChecksumPolicyTypeImpl.values()[rnd.nextInt(RemoteRepoChecksumPolicyTypeImpl.values().length)]
 
             // virtual
@@ -42,24 +43,30 @@ public class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
             pomRepositoryReferencesCleanupPolicy = PomCleanupPolicy.values()[rnd.nextInt(PomCleanupPolicy.values().length)]
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "gradlePackageTypeRepo")
     public void testGradleLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(checksumPolicyType, CoreMatchers.is(settings.getChecksumPolicyType()))
-            assertThat(handleReleases, CoreMatchers.is(settings.getHandleReleases()))
-            assertThat(handleSnapshots, CoreMatchers.is(settings.getHandleSnapshots()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))
-            assertThat(snapshotVersionBehavior, CoreMatchers.is(settings.getSnapshotVersionBehavior()))
-            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(settings.getSuppressPomConsistencyChecks()))
+            assertThat(checksumPolicyType, CoreMatchers.is(expectedSettings.getChecksumPolicyType()))
+            assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases()))
+            assertThat(handleSnapshots, CoreMatchers.is(expectedSettings.getHandleSnapshots()))
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
+            assertThat(snapshotVersionBehavior, CoreMatchers.is(expectedSettings.getSnapshotVersionBehavior()))
+            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
 
             // remote
             assertThat(fetchJarsEagerly, CoreMatchers.nullValue())
@@ -77,24 +84,26 @@ public class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "gradlePackageTypeRepo")
     public void testGradleRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
-            assertThat(handleReleases, CoreMatchers.is(settings.getHandleReleases())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))  // always in resp payload
+            assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))  // always in resp payload
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
-            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(settings.getSuppressPomConsistencyChecks())) // always sent by artifactory
+            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
+            // always sent by artifactory
 
             // remote
-            assertThat(fetchJarsEagerly, CoreMatchers.is(settings.getFetchJarsEagerly()))
-            assertThat(fetchSourcesEagerly, CoreMatchers.is(settings.getFetchSourcesEagerly()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
-            assertThat(rejectInvalidJars, CoreMatchers.is(settings.getRejectInvalidJars()))
+            assertThat(fetchJarsEagerly, CoreMatchers.is(expectedSettings.getFetchJarsEagerly()))
+            assertThat(fetchSourcesEagerly, CoreMatchers.is(expectedSettings.getFetchSourcesEagerly()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
+            assertThat(rejectInvalidJars, CoreMatchers.is(expectedSettings.getRejectInvalidJars()))
             // TODO: property is not returned by the artifactory, asserting on default value
             // assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(specRepo.getRemoteRepoChecksumPolicyType()))
             assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(RemoteRepoChecksumPolicyTypeImpl.generate_if_absent))
@@ -108,10 +117,11 @@ public class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "gradlePackageTypeRepo")
     public void testGradleVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -130,7 +140,8 @@ public class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // virtual
             assertThat(keyPair, CoreMatchers.is('')) // empty = keyPair is not set
-            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(settings.getPomRepositoryReferencesCleanupPolicy())) // always sent by artifactory
+            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(expectedSettings.getPomRepositoryReferencesCleanupPolicy()))
+            // always sent by artifactory
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/IvyPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/IvyPackageTypeRepositoryTests.groovy
@@ -1,25 +1,26 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.LocalRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.RemoteRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.SnapshotVersionBehaviorImpl
 import org.jfrog.artifactory.client.model.repository.PomCleanupPolicy
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.IvyRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `ivy` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new IvyRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new IvyRepositorySettingsImpl()
 
         settings.with {
             // local
@@ -34,7 +35,7 @@ public class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
             fetchJarsEagerly = rnd.nextBoolean()
             fetchSourcesEagerly = rnd.nextBoolean()
             listRemoteFolderItems = rnd.nextBoolean()
-            rejectInvalidJars= rnd.nextBoolean()
+            rejectInvalidJars = rnd.nextBoolean()
             remoteRepoChecksumPolicyType = RemoteRepoChecksumPolicyTypeImpl.values()[rnd.nextInt(RemoteRepoChecksumPolicyTypeImpl.values().length)]
 
             // virtual
@@ -42,24 +43,30 @@ public class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
             pomRepositoryReferencesCleanupPolicy = PomCleanupPolicy.values()[rnd.nextInt(PomCleanupPolicy.values().length)]
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "ivyPackageTypeRepo")
     public void testIvyLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(checksumPolicyType, CoreMatchers.is(settings.getChecksumPolicyType()))
-            assertThat(handleReleases, CoreMatchers.is(settings.getHandleReleases()))
-            assertThat(handleSnapshots, CoreMatchers.is(settings.getHandleSnapshots()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))
-            assertThat(snapshotVersionBehavior, CoreMatchers.is(settings.getSnapshotVersionBehavior()))
-            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(settings.getSuppressPomConsistencyChecks()))
+            assertThat(checksumPolicyType, CoreMatchers.is(expectedSettings.getChecksumPolicyType()))
+            assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases()))
+            assertThat(handleSnapshots, CoreMatchers.is(expectedSettings.getHandleSnapshots()))
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
+            assertThat(snapshotVersionBehavior, CoreMatchers.is(expectedSettings.getSnapshotVersionBehavior()))
+            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
 
             // remote
             assertThat(fetchJarsEagerly, CoreMatchers.nullValue())
@@ -77,24 +84,26 @@ public class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "ivyPackageTypeRepo")
     public void testIvyRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
-            assertThat(handleReleases, CoreMatchers.is(settings.getHandleReleases())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))  // always in resp payload
+            assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))  // always in resp payload
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
-            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(settings.getSuppressPomConsistencyChecks())) // always sent by artifactory
+            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
+            // always sent by artifactory
 
             // remote
-            assertThat(fetchJarsEagerly, CoreMatchers.is(settings.getFetchJarsEagerly()))
-            assertThat(fetchSourcesEagerly, CoreMatchers.is(settings.getFetchSourcesEagerly()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
-            assertThat(rejectInvalidJars, CoreMatchers.is(settings.getRejectInvalidJars()))
+            assertThat(fetchJarsEagerly, CoreMatchers.is(expectedSettings.getFetchJarsEagerly()))
+            assertThat(fetchSourcesEagerly, CoreMatchers.is(expectedSettings.getFetchSourcesEagerly()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
+            assertThat(rejectInvalidJars, CoreMatchers.is(expectedSettings.getRejectInvalidJars()))
             // TODO: property is not returned by the artifactory, asserting on default value
             // assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(specRepo.getRemoteRepoChecksumPolicyType()))
             assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(RemoteRepoChecksumPolicyTypeImpl.generate_if_absent))
@@ -108,10 +117,11 @@ public class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "ivyPackageTypeRepo")
     public void testIvyVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -130,7 +140,8 @@ public class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // virtual
             assertThat(keyPair, CoreMatchers.is('')) // empty = keyPair is not set
-            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(settings.getPomRepositoryReferencesCleanupPolicy())) // always sent by artifactory
+            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(expectedSettings.getPomRepositoryReferencesCleanupPolicy()))
+            // always sent by artifactory
         }
     }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/MavenPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/MavenPackageTypeRepositoryTests.groovy
@@ -6,6 +6,7 @@ import org.jfrog.artifactory.client.model.impl.LocalRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.RemoteRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.SnapshotVersionBehaviorImpl
 import org.jfrog.artifactory.client.model.repository.PomCleanupPolicy
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.MavenRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -17,9 +18,9 @@ import org.testng.annotations.Test
  */
 public class MavenPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new MavenRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new MavenRepositorySettingsImpl()
 
         settings.with {
             // local
@@ -42,24 +43,30 @@ public class MavenPackageTypeRepositoryTests extends BaseRepositoryTests {
             pomRepositoryReferencesCleanupPolicy = PomCleanupPolicy.values()[rnd.nextInt(PomCleanupPolicy.values().length)]
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "mavenPackageTypeRepo")
     public void testMavenLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(checksumPolicyType, CoreMatchers.is(settings.getChecksumPolicyType()))
-            assertThat(handleReleases, CoreMatchers.is(settings.getHandleReleases()))
-            assertThat(handleSnapshots, CoreMatchers.is(settings.getHandleSnapshots()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))
-            assertThat(snapshotVersionBehavior, CoreMatchers.is(settings.getSnapshotVersionBehavior()))
-            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(settings.getSuppressPomConsistencyChecks()))
+            assertThat(checksumPolicyType, CoreMatchers.is(expectedSettings.getChecksumPolicyType()))
+            assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases()))
+            assertThat(handleSnapshots, CoreMatchers.is(expectedSettings.getHandleSnapshots()))
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
+            assertThat(snapshotVersionBehavior, CoreMatchers.is(expectedSettings.getSnapshotVersionBehavior()))
+            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
 
             // remote
             assertThat(fetchJarsEagerly, CoreMatchers.nullValue())
@@ -77,24 +84,25 @@ public class MavenPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "mavenPackageTypeRepo")
     public void testMavenRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
-            assertThat(handleReleases, CoreMatchers.is(settings.getHandleReleases())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))  // always in resp payload
+            assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))  // always in resp payload
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
-            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(settings.getSuppressPomConsistencyChecks())) // always sent by artifactory
+            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks())) // always sent by artifactory
 
             // remote
-            assertThat(fetchJarsEagerly, CoreMatchers.is(settings.getFetchJarsEagerly()))
-            assertThat(fetchSourcesEagerly, CoreMatchers.is(settings.getFetchSourcesEagerly()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
-            assertThat(rejectInvalidJars, CoreMatchers.is(settings.getRejectInvalidJars()))
+            assertThat(fetchJarsEagerly, CoreMatchers.is(expectedSettings.getFetchJarsEagerly()))
+            assertThat(fetchSourcesEagerly, CoreMatchers.is(expectedSettings.getFetchSourcesEagerly()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
+            assertThat(rejectInvalidJars, CoreMatchers.is(expectedSettings.getRejectInvalidJars()))
             // TODO: property is not returned by the artifactory, asserting on default value
             // assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(specRepo.getRemoteRepoChecksumPolicyType()))
             assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(RemoteRepoChecksumPolicyTypeImpl.generate_if_absent))
@@ -108,10 +116,11 @@ public class MavenPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "mavenPackageTypeRepo")
     public void testMavenVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -130,7 +139,7 @@ public class MavenPackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // virtual
             assertThat(keyPair, CoreMatchers.is('')) // empty = keyPair is not set
-            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(settings.getPomRepositoryReferencesCleanupPolicy())) // always sent by artifactory
+            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(expectedSettings.getPomRepositoryReferencesCleanupPolicy())) // always sent by artifactory
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/NpmPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/NpmPackageTypeRepositoryTests.groovy
@@ -1,21 +1,22 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.NpmRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `npm` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class NpmPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings  = new NpmRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new NpmRepositorySettingsImpl()
 
         settings.with {
             // remote
@@ -28,16 +29,22 @@ public class NpmPackageTypeRepositoryTests extends BaseRepositoryTests {
             externalDependenciesRemoteRepo
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "npmPackageTypeRepo")
     public void testNpmLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
@@ -52,13 +59,14 @@ public class NpmPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "npmPackageTypeRepo")
     public void testNpmRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // remote
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
 
             // virtual
             assertThat(externalDependenciesEnabled, CoreMatchers.nullValue())
@@ -70,18 +78,19 @@ public class NpmPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "npmPackageTypeRepo")
     public void testNpmVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
 
             // virtual
-            assertThat(externalDependenciesEnabled, CoreMatchers.is(settings.getExternalDependenciesEnabled()))
-            assertThat(externalDependenciesPatterns, CoreMatchers.is(settings.getExternalDependenciesPatterns()))
-            assertThat(externalDependenciesRemoteRepo, CoreMatchers.is(settings.getExternalDependenciesRemoteRepo()))
+            assertThat(externalDependenciesEnabled, CoreMatchers.is(expectedSettings.getExternalDependenciesEnabled()))
+            assertThat(externalDependenciesPatterns, CoreMatchers.is(expectedSettings.getExternalDependenciesPatterns()))
+            assertThat(externalDependenciesRemoteRepo, CoreMatchers.is(expectedSettings.getExternalDependenciesRemoteRepo()))
         }
     }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/NugetPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/NugetPackageTypeRepositoryTests.groovy
@@ -1,21 +1,22 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.NugetRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `nuget` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class NugetPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new NugetRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new NugetRepositorySettingsImpl()
 
         settings.with {
             // local
@@ -30,19 +31,25 @@ public class NugetPackageTypeRepositoryTests extends BaseRepositoryTests {
             forceNugetAuthentication = rnd.nextBoolean()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "nugetPackageTypeRepo")
     public void testNugetLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             // TODO: property is not returned by the artifactory
             // assertThat(downloadContextPath, CoreMatchers.is(specRepo.getDownloadContextPath()))
             assertThat(downloadContextPath, CoreMatchers.is(CoreMatchers.nullValue()))
@@ -54,50 +61,53 @@ public class NugetPackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
 
             // local + remote
-            assertThat(forceNugetAuthentication, CoreMatchers.is(settings.getForceNugetAuthentication()))
+            assertThat(forceNugetAuthentication, CoreMatchers.is(expectedSettings.getForceNugetAuthentication()))
         }
     }
 
     @Test(groups = "nugetPackageTypeRepo")
     public void testNugetRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
+            // always in resp payload
             assertThat(downloadContextPath, CoreMatchers.is(CoreMatchers.nullValue()))
             assertThat(feedContextPath, CoreMatchers.is(CoreMatchers.nullValue()))
 
             // remote
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
 
             // local + remote
-            assertThat(forceNugetAuthentication, CoreMatchers.is(settings.getForceNugetAuthentication()))
+            assertThat(forceNugetAuthentication, CoreMatchers.is(expectedSettings.getForceNugetAuthentication()))
         }
     }
 
     @Test(groups = "nugetPackageTypeRepo")
     public void testNugetVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(maxUniqueSnapshots, CoreMatchers.is(CoreMatchers.nullValue())) // always in resp payload
             assertThat(downloadContextPath, CoreMatchers.is(CoreMatchers.nullValue()))
             assertThat(feedContextPath, CoreMatchers.is(CoreMatchers.nullValue()))
 
-
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
 
             // local + remote
-            assertThat(forceNugetAuthentication, CoreMatchers.is(settings.getForceNugetAuthentication())) // always in resp payload
+            assertThat(forceNugetAuthentication, CoreMatchers.is(expectedSettings.getForceNugetAuthentication()))
+            // always in resp payload
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/OpkgPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/OpkgPackageTypeRepositoryTests.groovy
@@ -1,27 +1,33 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.OpkgRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `opkg` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class OpkgPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new OpkgRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new OpkgRepositorySettingsImpl()
 
         settings.with {
             // remote
             listRemoteFolderItems = rnd.nextBoolean()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         // only local and remote repository supported
         prepareVirtualRepo = false
 
@@ -31,10 +37,11 @@ public class OpkgPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "opkgPackageTypeRepo")
     public void testOpkgLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -42,11 +49,12 @@ public class OpkgPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "opkgPackageTypeRepo")
     public void testOpkgRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/P2PackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/P2PackageTypeRepositoryTests.groovy
@@ -1,25 +1,31 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.LocalRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.RemoteRepoChecksumPolicyTypeImpl
+import org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl
 import org.jfrog.artifactory.client.model.impl.SnapshotVersionBehaviorImpl
 import org.jfrog.artifactory.client.model.repository.PomCleanupPolicy
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.P2RepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `p2` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class P2PackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new P2RepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        if(repositoryType == RepositoryTypeImpl.LOCAL) {
+            return null
+        }
+
+        def settings = new P2RepositorySettingsImpl()
 
         settings.with {
             // local
@@ -34,7 +40,7 @@ public class P2PackageTypeRepositoryTests extends BaseRepositoryTests {
             fetchJarsEagerly = rnd.nextBoolean()
             fetchSourcesEagerly = rnd.nextBoolean()
             listRemoteFolderItems = rnd.nextBoolean()
-            rejectInvalidJars= rnd.nextBoolean()
+            rejectInvalidJars = rnd.nextBoolean()
             remoteRepoChecksumPolicyType = RemoteRepoChecksumPolicyTypeImpl.values()[rnd.nextInt(RemoteRepoChecksumPolicyTypeImpl.values().length)]
 
             // virtual
@@ -42,6 +48,11 @@ public class P2PackageTypeRepositoryTests extends BaseRepositoryTests {
             pomRepositoryReferencesCleanupPolicy = PomCleanupPolicy.values()[rnd.nextInt(PomCleanupPolicy.values().length)]
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         // only remote ant virtual repository is supported
         prepareLocalRepo = false
 
@@ -51,24 +62,26 @@ public class P2PackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "p2PackageTypeRepo")
     public void testP2RemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
-            assertThat(handleReleases, CoreMatchers.is(settings.getHandleReleases())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))  // always in resp payload
+            assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))  // always in resp payload
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
-            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(settings.getSuppressPomConsistencyChecks())) // always sent by artifactory
+            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
+            // always sent by artifactory
 
             // remote
-            assertThat(fetchJarsEagerly, CoreMatchers.is(settings.getFetchJarsEagerly()))
-            assertThat(fetchSourcesEagerly, CoreMatchers.is(settings.getFetchSourcesEagerly()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
-            assertThat(rejectInvalidJars, CoreMatchers.is(settings.getRejectInvalidJars()))
+            assertThat(fetchJarsEagerly, CoreMatchers.is(expectedSettings.getFetchJarsEagerly()))
+            assertThat(fetchSourcesEagerly, CoreMatchers.is(expectedSettings.getFetchSourcesEagerly()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
+            assertThat(rejectInvalidJars, CoreMatchers.is(expectedSettings.getRejectInvalidJars()))
             // TODO: property is not returned by the artifactory, asserting on default value
             // assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(specRepo.getRemoteRepoChecksumPolicyType()))
             assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(RemoteRepoChecksumPolicyTypeImpl.generate_if_absent))
@@ -82,10 +95,11 @@ public class P2PackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "p2PackageTypeRepo")
     public void testP2VirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -104,7 +118,8 @@ public class P2PackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // virtual
             assertThat(keyPair, CoreMatchers.is('')) // empty = keyPair is not set
-            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(settings.getPomRepositoryReferencesCleanupPolicy())) // always sent by artifactory
+            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(expectedSettings.getPomRepositoryReferencesCleanupPolicy()))
+            // always sent by artifactory
         }
     }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/PuppetPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/PuppetPackageTypeRepositoryTests.groovy
@@ -1,6 +1,8 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.PuppetRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -10,39 +12,46 @@ import org.testng.annotations.Test
  */
 public class PuppetPackageTypeRepositoryTests extends BaseRepositoryTests {
 
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        return new PuppetRepositorySettingsImpl()
+    }
+
     @BeforeMethod
     protected void setUp() {
-        settings = new PuppetRepositorySettingsImpl()
         super.setUp()
     }
 
     @Test(groups = "puppetPackageTypeRepo")
     public void testPuppetLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 
     @Test(groups = "puppetPackageTypeRepo")
     public void testPuppetRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 
     @Test(groups = "puppetPackageTypeRepo")
     public void testPuppetVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/PypiPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/PypiPackageTypeRepositoryTests.groovy
@@ -2,6 +2,7 @@ package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
 import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.PypiRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -13,25 +14,30 @@ import org.testng.annotations.Test
  */
 public class PypiPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new PypiRepositorySettingsImpl()
-
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        RepositorySettings settings = new PypiRepositorySettingsImpl()
         settings.with {
             // remote
             listRemoteFolderItems = rnd.nextBoolean()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "pypiPackageTypeRepo")
     public void testPypiLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -39,21 +45,23 @@ public class PypiPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "pypiPackageTypeRepo")
     public void testPypiRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
 
     @Test(groups = "pypiPackageTypeRepo")
     public void testPypiVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ReplicationTests.groovy
@@ -1,12 +1,18 @@
 package org.jfrog.artifactory.client
 
 import groovyx.net.http.HttpResponseException
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
-import org.jfrog.artifactory.client.model.impl.RemoteReplicationImpl
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 public class ReplicationTests extends BaseRepositoryTests {
+
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        return null
+    }
 
     @BeforeMethod
     protected void setUp() {

--- a/services/src/test/groovy/org/jfrog/artifactory/client/RpmPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/RpmPackageTypeRepositoryTests.groovy
@@ -1,6 +1,8 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.RpmRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -12,9 +14,9 @@ import org.testng.annotations.Test
  */
 public class RpmPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new RpmRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new RpmRepositorySettingsImpl()
 
         settings.with {
             // local
@@ -27,6 +29,11 @@ public class RpmPackageTypeRepositoryTests extends BaseRepositoryTests {
             yumRootDepth = rnd.nextInt()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         // only local and remote repository supported
         prepareVirtualRepo = false
 
@@ -36,18 +43,19 @@ public class RpmPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "rpmPackageTypeRepo")
     public void testRpmLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(calculateYumMetadata, CoreMatchers.is(settings.getCalculateYumMetadata()))
-            assertThat(enableFileListsIndexing, CoreMatchers.is(settings.getEnableFileListsIndexing()))
+            assertThat(calculateYumMetadata, CoreMatchers.is(expectedSettings.getCalculateYumMetadata()))
+            assertThat(enableFileListsIndexing, CoreMatchers.is(expectedSettings.getEnableFileListsIndexing()))
             // TODO: property is not returned by the artifactory
             // assertThat(groupFileNames, CoreMatchers.is(specRepo.getGroupFileNames()))
             assertThat(groupFileNames, CoreMatchers.is(CoreMatchers.nullValue()))
-            assertThat(yumRootDepth, CoreMatchers.is(settings.getYumRootDepth()))
+            assertThat(yumRootDepth, CoreMatchers.is(expectedSettings.getYumRootDepth()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(CoreMatchers.nullValue()))
@@ -57,13 +65,14 @@ public class RpmPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "rpmPackageTypeRepo")
     public void testRpmRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // remote
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
 
             // local
             assertThat(enableFileListsIndexing, CoreMatchers.is(CoreMatchers.nullValue()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/SbtPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/SbtPackageTypeRepositoryTests.groovy
@@ -1,25 +1,26 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.LocalRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.RemoteRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.SnapshotVersionBehaviorImpl
 import org.jfrog.artifactory.client.model.repository.PomCleanupPolicy
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.SbtRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 /**
  * test that client correctly sends and receives repository configuration with `sbt` package type
- * 
+ *
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new SbtRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new SbtRepositorySettingsImpl()
 
         settings.with {
             // local
@@ -34,7 +35,7 @@ public class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
             fetchJarsEagerly = rnd.nextBoolean()
             fetchSourcesEagerly = rnd.nextBoolean()
             listRemoteFolderItems = rnd.nextBoolean()
-            rejectInvalidJars= rnd.nextBoolean()
+            rejectInvalidJars = rnd.nextBoolean()
             remoteRepoChecksumPolicyType = RemoteRepoChecksumPolicyTypeImpl.values()[rnd.nextInt(RemoteRepoChecksumPolicyTypeImpl.values().length)]
 
             // virtual
@@ -42,24 +43,30 @@ public class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
             pomRepositoryReferencesCleanupPolicy = PomCleanupPolicy.values()[rnd.nextInt(PomCleanupPolicy.values().length)]
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         super.setUp()
     }
 
     @Test(groups = "sbtPackageTypeRepo")
     public void testSbtLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
-            assertThat(checksumPolicyType, CoreMatchers.is(settings.getChecksumPolicyType()))
-            assertThat(handleReleases, CoreMatchers.is(settings.getHandleReleases()))
-            assertThat(handleSnapshots, CoreMatchers.is(settings.getHandleSnapshots()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))
-            assertThat(snapshotVersionBehavior, CoreMatchers.is(settings.getSnapshotVersionBehavior()))
-            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(settings.getSuppressPomConsistencyChecks()))
+            assertThat(checksumPolicyType, CoreMatchers.is(expectedSettings.getChecksumPolicyType()))
+            assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases()))
+            assertThat(handleSnapshots, CoreMatchers.is(expectedSettings.getHandleSnapshots()))
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
+            assertThat(snapshotVersionBehavior, CoreMatchers.is(expectedSettings.getSnapshotVersionBehavior()))
+            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
 
             // remote
             assertThat(fetchJarsEagerly, CoreMatchers.nullValue())
@@ -77,24 +84,26 @@ public class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "sbtPackageTypeRepo")
     public void testSbtRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
-            assertThat(handleReleases, CoreMatchers.is(settings.getHandleReleases())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots())) // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(settings.getMaxUniqueSnapshots()))  // always in resp payload
+            assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots())) // always in resp payload
+            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))  // always in resp payload
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
-            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(settings.getSuppressPomConsistencyChecks())) // always sent by artifactory
+            assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
+            // always sent by artifactory
 
             // remote
-            assertThat(fetchJarsEagerly, CoreMatchers.is(settings.getFetchJarsEagerly()))
-            assertThat(fetchSourcesEagerly, CoreMatchers.is(settings.getFetchSourcesEagerly()))
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
-            assertThat(rejectInvalidJars, CoreMatchers.is(settings.getRejectInvalidJars()))
+            assertThat(fetchJarsEagerly, CoreMatchers.is(expectedSettings.getFetchJarsEagerly()))
+            assertThat(fetchSourcesEagerly, CoreMatchers.is(expectedSettings.getFetchSourcesEagerly()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
+            assertThat(rejectInvalidJars, CoreMatchers.is(expectedSettings.getRejectInvalidJars()))
             // TODO: property is not returned by the artifactory, asserting on default value
             // assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(specRepo.getRemoteRepoChecksumPolicyType()))
             assertThat(remoteRepoChecksumPolicyType, CoreMatchers.is(RemoteRepoChecksumPolicyTypeImpl.generate_if_absent))
@@ -108,10 +117,11 @@ public class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "sbtPackageTypeRepo")
     public void testSbtVirtualRepo() {
         artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -130,7 +140,8 @@ public class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // virtual
             assertThat(keyPair, CoreMatchers.is('')) // empty = keyPair is not set
-            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(settings.getPomRepositoryReferencesCleanupPolicy())) // always sent by artifactory
+            assertThat(pomRepositoryReferencesCleanupPolicy, CoreMatchers.is(expectedSettings.getPomRepositoryReferencesCleanupPolicy()))
+            // always sent by artifactory
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/VagrantPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/VagrantPackageTypeRepositoryTests.groovy
@@ -2,6 +2,7 @@ package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
 import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.VagrantRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -13,13 +14,13 @@ import org.testng.annotations.Test
  */
 public class VagrantPackageTypeRepositoryTests extends BaseRepositoryTests {
 
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        return new VagrantRepositorySettingsImpl()
+    }
+
     @BeforeMethod
     protected void setUp() {
-        settings = new VagrantRepositorySettingsImpl()
-
-        settings.with {
-        }
-
         // only local repository supported
         prepareRemoteRepo = false
         prepareVirtualRepo = false
@@ -30,10 +31,11 @@ public class VagrantPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "vagrantPackageTypeRepo")
     public void testVagrantLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
-            assertThat(packageType, CoreMatchers.is(settings.getPackageType()))
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/XrayPropertiesRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/XrayPropertiesRepositoryTests.groovy
@@ -1,7 +1,9 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.VirtualRepository
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.MavenRepositorySettingsImpl
 import org.jfrog.artifactory.client.model.xray.settings.impl.XraySettingsImpl
 import org.testng.annotations.BeforeMethod
@@ -11,9 +13,13 @@ import org.testng.annotations.Test
  * @author Ihor Banadiga (ihorb@jfrog.com)
  */
 class XrayPropertiesRepositoryTests extends BaseRepositoryTests {
+  @Override
+  RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+    return new MavenRepositorySettingsImpl()
+  }
+
   @BeforeMethod
   protected void setUp() {
-    settings = new MavenRepositorySettingsImpl()
     xraySettings = new XraySettingsImpl()
 
     xraySettings.with {

--- a/services/src/test/groovy/org/jfrog/artifactory/client/YumPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/YumPackageTypeRepositoryTests.groovy
@@ -1,7 +1,9 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.YumRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -13,9 +15,9 @@ import org.testng.annotations.Test
  */
 public class YumPackageTypeRepositoryTests extends BaseRepositoryTests {
 
-    @BeforeMethod
-    protected void setUp() {
-        settings = new YumRepositorySettingsImpl()
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new YumRepositorySettingsImpl()
 
         settings.with {
             // local
@@ -27,6 +29,11 @@ public class YumPackageTypeRepositoryTests extends BaseRepositoryTests {
             yumRootDepth = rnd.nextInt()
         }
 
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
         // only local and remote repository supported
         prepareVirtualRepo = false
 
@@ -36,6 +43,7 @@ public class YumPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "yumPackageTypeRepo")
     public void testYumLocalRepo() {
         artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
@@ -43,11 +51,11 @@ public class YumPackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(packageType, CoreMatchers.is(PackageTypeImpl.rpm))
 
             // local
-            assertThat(calculateYumMetadata, CoreMatchers.is(settings.getCalculateYumMetadata()))
+            assertThat(calculateYumMetadata, CoreMatchers.is(expectedSettings.getCalculateYumMetadata()))
             // TODO: property is not returned by the artifactory
             // assertThat(groupFileNames, CoreMatchers.is(specRepo.getGroupFileNames()))
             assertThat(groupFileNames, CoreMatchers.is(CoreMatchers.nullValue()))
-            assertThat(yumRootDepth, CoreMatchers.is(settings.getYumRootDepth()))
+            assertThat(yumRootDepth, CoreMatchers.is(expectedSettings.getYumRootDepth()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(CoreMatchers.nullValue()))
@@ -57,6 +65,7 @@ public class YumPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Test(groups = "yumPackageTypeRepo")
     public void testYumRemoteRepo() {
         artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
         resp.getRepositorySettings().with {
@@ -64,7 +73,7 @@ public class YumPackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(packageType, CoreMatchers.is(PackageTypeImpl.rpm))
 
             // remote
-            assertThat(listRemoteFolderItems, CoreMatchers.is(settings.getListRemoteFolderItems()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
 
             // local
             assertThat(calculateYumMetadata, CoreMatchers.is(CoreMatchers.nullValue()))

--- a/services/src/test/java/org/jfrog/artifactory/client/RepositoryTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/RepositoryTests.java
@@ -201,7 +201,7 @@ public class RepositoryTests extends ArtifactoryTestsBase {
         List<String> propertySets = localRepo.getPropertySets();
         assertEquals(propertySets.size(), 1);
         assertEquals(propertySets.get(0), ("artifactory"));
-        assertEquals(localRepo.getRepoLayoutRef(), "maven-2-default");
+        assertEquals(localRepo.getRepoLayoutRef(), "simple-default");
     }
 
     @Test(dependsOnMethods = "testCreate")


### PR DESCRIPTION
In the current behavior, the client creates all the repositories with **maven** layout as default.
This fix will add the right layout corresponding to the repo type