### PR TITLE
Added builders for replication classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,33 +230,35 @@ artifactory.repository("RepoName").replications.delete()
 
 ##### Creating or replacing a replication on a local repository
 ```
-LocalReplication replication = new LocalReplicationImpl()
-replication.url = "http://hostname1:port/artifactory/RepoName"
-replication.socketTimeoutMillis = 30000
-replication.username = 'john.doe'
-replication.password = 'secret'
-replication.enableEventReplication = false
-replication.enabled = false
-replication.cronExp = '0 0 0/2 * * ?'
-replication.syncDeletes = true
-replication.syncProperties = true
-replication.syncStatistics = true
-replication.pathPrefix = ''
-replication.repoKey = "RepoName"
+LocalReplication replication = new LocalReplicationBuilderImpl()
+    .url("http://hostname1:port/artifactory/RepoName")
+    .socketTimeoutMillis(30000)
+    .username("john.doe")
+    .password("secret")
+    .enableEventReplication(false)
+    .enabled(false)
+    .cronExp("0 0 0/2 * * ?")
+    .syncDeletes(true)
+    .syncProperties(true)
+    .syncStatistics(true)
+    .pathPrefix("")
+    .repoKey("RepoName")
+    .build();
 
-artifactory.repository("RepoName").replications.createOrReplace(replication)
+artifactory.repository("RepoName").getReplications().createOrReplace(replication);
 ```
 
 ##### Creating or replacing a replication on a remote repository
 ```
-RemoteReplication replication = new RemoteReplicationImpl()
-replication.enabled = false
-replication.cronExp = '0 0 0/2 * * ?'
-replication.syncDeletes = true
-replication.syncProperties = true
-replication.repoKey = "RepoName"
+RemoteReplication replication = new RemoteReplicationBuilderImpl()
+    .enabled(false)
+    .cronExp("0 0 0/2 * * ?")
+    .syncDeletes(true)
+    .syncProperties(true)
+    .repoKey("RepoName")
+    .build();
 
-artifactory.repository("RepoName").replications.createOrReplace(replication)
+artifactory.repository("RepoName").getReplications().createOrReplace(replication)
 ```
 
 ##### Managing Xray properties

--- a/api/src/main/java/org/jfrog/artifactory/client/model/builder/LocalReplicationBuilder.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/builder/LocalReplicationBuilder.java
@@ -1,0 +1,34 @@
+
+package org.jfrog.artifactory.client.model.builder;
+
+import org.jfrog.artifactory.client.model.LocalReplication;
+import org.jfrog.artifactory.client.model.Principal;
+
+public interface LocalReplicationBuilder {
+
+    LocalReplicationBuilder enabled(boolean enabled);
+
+    LocalReplicationBuilder cronExp(String cronExp);
+
+    LocalReplicationBuilder syncDeletes(boolean syncDeletes);
+
+    LocalReplicationBuilder syncProperties(boolean syncProperties);
+
+    LocalReplicationBuilder repoKey(String repoKey);
+
+    LocalReplicationBuilder url(String url);
+
+    LocalReplicationBuilder socketTimeoutMillis(long socketTimeoutMillis);
+
+    LocalReplicationBuilder username(String username);
+
+    LocalReplicationBuilder password(String password);
+
+    LocalReplicationBuilder enableEventReplication(boolean enableEventReplication);
+
+    LocalReplicationBuilder syncStatistics(boolean syncStatistics);
+
+    LocalReplicationBuilder pathPrefix(String pathPrefix);
+
+    LocalReplication build();
+}

--- a/api/src/main/java/org/jfrog/artifactory/client/model/builder/LocalReplicationBuilder.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/builder/LocalReplicationBuilder.java
@@ -4,17 +4,7 @@ package org.jfrog.artifactory.client.model.builder;
 import org.jfrog.artifactory.client.model.LocalReplication;
 import org.jfrog.artifactory.client.model.Principal;
 
-public interface LocalReplicationBuilder {
-
-    LocalReplicationBuilder enabled(boolean enabled);
-
-    LocalReplicationBuilder cronExp(String cronExp);
-
-    LocalReplicationBuilder syncDeletes(boolean syncDeletes);
-
-    LocalReplicationBuilder syncProperties(boolean syncProperties);
-
-    LocalReplicationBuilder repoKey(String repoKey);
+public interface LocalReplicationBuilder extends ReplicationBuilder<LocalReplicationBuilder> {
 
     LocalReplicationBuilder url(String url);
 

--- a/api/src/main/java/org/jfrog/artifactory/client/model/builder/RemoteReplicationBuilder.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/builder/RemoteReplicationBuilder.java
@@ -1,0 +1,19 @@
+
+package org.jfrog.artifactory.client.model.builder;
+
+import org.jfrog.artifactory.client.model.RemoteReplication;
+
+public interface RemoteReplicationBuilder {
+
+    RemoteReplicationBuilder enabled(boolean enabled);
+
+    RemoteReplicationBuilder cronExp(String cronExp);
+
+    RemoteReplicationBuilder syncDeletes(boolean syncDeletes);
+
+    RemoteReplicationBuilder syncProperties(boolean syncProperties);
+
+    RemoteReplicationBuilder repoKey(String repoKey);
+
+    RemoteReplication build();
+}

--- a/api/src/main/java/org/jfrog/artifactory/client/model/builder/RemoteReplicationBuilder.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/builder/RemoteReplicationBuilder.java
@@ -3,17 +3,7 @@ package org.jfrog.artifactory.client.model.builder;
 
 import org.jfrog.artifactory.client.model.RemoteReplication;
 
-public interface RemoteReplicationBuilder {
-
-    RemoteReplicationBuilder enabled(boolean enabled);
-
-    RemoteReplicationBuilder cronExp(String cronExp);
-
-    RemoteReplicationBuilder syncDeletes(boolean syncDeletes);
-
-    RemoteReplicationBuilder syncProperties(boolean syncProperties);
-
-    RemoteReplicationBuilder repoKey(String repoKey);
+public interface RemoteReplicationBuilder extends ReplicationBuilder<RemoteReplicationBuilder> {
 
     RemoteReplication build();
 }

--- a/api/src/main/java/org/jfrog/artifactory/client/model/builder/ReplicationBuilder.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/builder/ReplicationBuilder.java
@@ -1,0 +1,17 @@
+
+package org.jfrog.artifactory.client.model.builder;
+
+import org.jfrog.artifactory.client.model.LocalReplication;
+
+public interface ReplicationBuilder<B extends ReplicationBuilder> {
+
+    B enabled(boolean enabled);
+
+    B cronExp(String cronExp);
+
+    B syncDeletes(boolean syncDeletes);
+
+    B syncProperties(boolean syncProperties);
+
+    B repoKey(String repoKey);
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-currentVersion=2.5.x-SNAPSHOT
+currentVersion=2.5.2

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalReplicationBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalReplicationBuilderImpl.groovy
@@ -4,7 +4,7 @@ import org.jfrog.artifactory.client.model.LocalReplication
 import org.jfrog.artifactory.client.model.builder.LocalReplicationBuilder
 import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
 
-class LocalReplicationBuilderImpl extends ReplicationBuilderBase<LocalReplicationBuilder> {
+class LocalReplicationBuilderImpl extends ReplicationBuilderBase<LocalReplicationBuilder> implements LocalReplicationBuilder {
 
     private String url;
 

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalReplicationBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalReplicationBuilderImpl.groovy
@@ -1,0 +1,125 @@
+package org.jfrog.artifactory.client.model.builder.impl
+
+import org.jfrog.artifactory.client.model.Group
+import org.jfrog.artifactory.client.model.LocalReplication
+import org.jfrog.artifactory.client.model.builder.GroupBuilder
+import org.jfrog.artifactory.client.model.builder.LocalReplicationBuilder
+import org.jfrog.artifactory.client.model.impl.GroupImpl
+import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
+
+class LocalReplicationBuilderImpl implements LocalReplicationBuilder {
+
+    private boolean enabled;
+
+    private String cronExp;
+
+    private boolean syncDeletes;
+
+    private boolean syncProperties;
+
+    private String repoKey;
+
+    private String url;
+
+    private long socketTimeoutMillis;
+
+    private String username;
+
+    private String password;
+
+    private boolean enableEventReplication;
+
+    private boolean syncStatistics;
+
+    private String pathPrefix;
+
+    @Override
+    LocalReplicationBuilder enabled(boolean enabled) {
+        this.enabled = enabled;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder cronExp(String cronExp) {
+        this.cronExp = cronExp;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder syncDeletes(boolean syncDeletes) {
+        this.syncDeletes = syncDeletes;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder syncProperties(boolean syncProperties) {
+        this.syncProperties = syncProperties;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder repoKey(String repoKey) {
+        this.repoKey = repoKey;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder url(String url) {
+        this.url = url;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder socketTimeoutMillis(long socketTimeoutMillis) {
+        this.socketTimeoutMillis = socketTimeoutMillis;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder username(String username) {
+        this.username = username;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder password(String password) {
+        this.password = password;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder enableEventReplication(boolean enableEventReplication) {
+        this.enableEventReplication = enableEventReplication;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder syncStatistics(boolean syncStatistics) {
+        this.syncStatistics = syncStatistics;
+
+        return this;
+    }
+
+    @Override
+    LocalReplicationBuilder pathPrefix(String pathPrefix) {
+        this.pathPrefix = pathPrefix;
+
+        return this;
+    }
+
+    @Override
+    LocalReplication build() {
+        new LocalReplicationImpl(url, socketTimeoutMillis, username, password, enableEventReplication, syncStatistics,
+                enabled, cronExp, syncDeletes, syncProperties, pathPrefix, repoKey);
+    }
+}

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalReplicationBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalReplicationBuilderImpl.groovy
@@ -20,6 +20,21 @@ class LocalReplicationBuilderImpl extends ReplicationBuilderBase<LocalReplicatio
 
     private String pathPrefix;
 
+    LocalReplicationBuilderImpl() {
+    }
+
+    LocalReplicationBuilderImpl(LocalReplication replication) {
+        super(replication);
+
+        this.url = replication.url;
+        this.socketTimeoutMillis = replication.socketTimeoutMillis;
+        this.username = replication.username;
+        this.password = replication.password;
+        this.enableEventReplication = replication.enableEventReplication;
+        this.syncStatistics = replication.syncStatistics;
+        this.pathPrefix = replication.pathPrefix;
+    }
+
     LocalReplicationBuilder url(String url) {
         this.url = url;
 

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalReplicationBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalReplicationBuilderImpl.groovy
@@ -1,23 +1,10 @@
 package org.jfrog.artifactory.client.model.builder.impl
 
-import org.jfrog.artifactory.client.model.Group
 import org.jfrog.artifactory.client.model.LocalReplication
-import org.jfrog.artifactory.client.model.builder.GroupBuilder
 import org.jfrog.artifactory.client.model.builder.LocalReplicationBuilder
-import org.jfrog.artifactory.client.model.impl.GroupImpl
 import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
 
-class LocalReplicationBuilderImpl implements LocalReplicationBuilder {
-
-    private boolean enabled;
-
-    private String cronExp;
-
-    private boolean syncDeletes;
-
-    private boolean syncProperties;
-
-    private String repoKey;
+class LocalReplicationBuilderImpl extends ReplicationBuilderBase<LocalReplicationBuilder> {
 
     private String url;
 
@@ -33,91 +20,48 @@ class LocalReplicationBuilderImpl implements LocalReplicationBuilder {
 
     private String pathPrefix;
 
-    @Override
-    LocalReplicationBuilder enabled(boolean enabled) {
-        this.enabled = enabled;
-
-        return this;
-    }
-
-    @Override
-    LocalReplicationBuilder cronExp(String cronExp) {
-        this.cronExp = cronExp;
-
-        return this;
-    }
-
-    @Override
-    LocalReplicationBuilder syncDeletes(boolean syncDeletes) {
-        this.syncDeletes = syncDeletes;
-
-        return this;
-    }
-
-    @Override
-    LocalReplicationBuilder syncProperties(boolean syncProperties) {
-        this.syncProperties = syncProperties;
-
-        return this;
-    }
-
-    @Override
-    LocalReplicationBuilder repoKey(String repoKey) {
-        this.repoKey = repoKey;
-
-        return this;
-    }
-
-    @Override
     LocalReplicationBuilder url(String url) {
         this.url = url;
 
         return this;
     }
 
-    @Override
     LocalReplicationBuilder socketTimeoutMillis(long socketTimeoutMillis) {
         this.socketTimeoutMillis = socketTimeoutMillis;
 
         return this;
     }
 
-    @Override
     LocalReplicationBuilder username(String username) {
         this.username = username;
 
         return this;
     }
 
-    @Override
     LocalReplicationBuilder password(String password) {
         this.password = password;
 
         return this;
     }
 
-    @Override
     LocalReplicationBuilder enableEventReplication(boolean enableEventReplication) {
         this.enableEventReplication = enableEventReplication;
 
         return this;
     }
 
-    @Override
     LocalReplicationBuilder syncStatistics(boolean syncStatistics) {
         this.syncStatistics = syncStatistics;
 
         return this;
     }
 
-    @Override
     LocalReplicationBuilder pathPrefix(String pathPrefix) {
         this.pathPrefix = pathPrefix;
 
         return this;
     }
 
-    @Override
     LocalReplication build() {
         new LocalReplicationImpl(url, socketTimeoutMillis, username, password, enableEventReplication, syncStatistics,
                 enabled, cronExp, syncDeletes, syncProperties, pathPrefix, repoKey);

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteReplicationBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteReplicationBuilderImpl.groovy
@@ -1,58 +1,10 @@
 package org.jfrog.artifactory.client.model.builder.impl
 
-import org.jfrog.artifactory.client.model.LocalReplication
 import org.jfrog.artifactory.client.model.RemoteReplication
-import org.jfrog.artifactory.client.model.builder.LocalReplicationBuilder
 import org.jfrog.artifactory.client.model.builder.RemoteReplicationBuilder
-import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
 import org.jfrog.artifactory.client.model.impl.RemoteReplicationImpl
 
-class RemoteReplicationBuilderImpl implements RemoteReplicationBuilder {
-
-    private boolean enabled;
-
-    private String cronExp;
-
-    private boolean syncDeletes;
-
-    private boolean syncProperties;
-
-    private String repoKey;
-
-    @Override
-    RemoteReplicationBuilder enabled(boolean enabled) {
-        this.enabled = enabled;
-
-        return this;
-    }
-
-    @Override
-    RemoteReplicationBuilder cronExp(String cronExp) {
-        this.cronExp = cronExp;
-
-        return this;
-    }
-
-    @Override
-    RemoteReplicationBuilder syncDeletes(boolean syncDeletes) {
-        this.syncDeletes = syncDeletes;
-
-        return this;
-    }
-
-    @Override
-    RemoteReplicationBuilder syncProperties(boolean syncProperties) {
-        this.syncProperties = syncProperties;
-
-        return this;
-    }
-
-    @Override
-    RemoteReplicationBuilder repoKey(String repoKey) {
-        this.repoKey = repoKey;
-
-        return this;
-    }
+class RemoteReplicationBuilderImpl extends ReplicationBuilderBase<RemoteReplicationBuilder> {
 
     RemoteReplication build() {
         new RemoteReplicationImpl(enabled, cronExp, syncDeletes, syncProperties, repoKey);

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteReplicationBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteReplicationBuilderImpl.groovy
@@ -1,0 +1,60 @@
+package org.jfrog.artifactory.client.model.builder.impl
+
+import org.jfrog.artifactory.client.model.LocalReplication
+import org.jfrog.artifactory.client.model.RemoteReplication
+import org.jfrog.artifactory.client.model.builder.LocalReplicationBuilder
+import org.jfrog.artifactory.client.model.builder.RemoteReplicationBuilder
+import org.jfrog.artifactory.client.model.impl.LocalReplicationImpl
+import org.jfrog.artifactory.client.model.impl.RemoteReplicationImpl
+
+class RemoteReplicationBuilderImpl implements RemoteReplicationBuilder {
+
+    private boolean enabled;
+
+    private String cronExp;
+
+    private boolean syncDeletes;
+
+    private boolean syncProperties;
+
+    private String repoKey;
+
+    @Override
+    RemoteReplicationBuilder enabled(boolean enabled) {
+        this.enabled = enabled;
+
+        return this;
+    }
+
+    @Override
+    RemoteReplicationBuilder cronExp(String cronExp) {
+        this.cronExp = cronExp;
+
+        return this;
+    }
+
+    @Override
+    RemoteReplicationBuilder syncDeletes(boolean syncDeletes) {
+        this.syncDeletes = syncDeletes;
+
+        return this;
+    }
+
+    @Override
+    RemoteReplicationBuilder syncProperties(boolean syncProperties) {
+        this.syncProperties = syncProperties;
+
+        return this;
+    }
+
+    @Override
+    RemoteReplicationBuilder repoKey(String repoKey) {
+        this.repoKey = repoKey;
+
+        return this;
+    }
+
+    RemoteReplication build() {
+        new RemoteReplicationImpl(enabled, cronExp, syncDeletes, syncProperties, repoKey);
+    }
+}

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteReplicationBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteReplicationBuilderImpl.groovy
@@ -4,7 +4,7 @@ import org.jfrog.artifactory.client.model.RemoteReplication
 import org.jfrog.artifactory.client.model.builder.RemoteReplicationBuilder
 import org.jfrog.artifactory.client.model.impl.RemoteReplicationImpl
 
-class RemoteReplicationBuilderImpl extends ReplicationBuilderBase<RemoteReplicationBuilder> {
+class RemoteReplicationBuilderImpl extends ReplicationBuilderBase<RemoteReplicationBuilder> implements RemoteReplicationBuilder {
 
     RemoteReplicationBuilderImpl() {
     }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteReplicationBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteReplicationBuilderImpl.groovy
@@ -6,6 +6,13 @@ import org.jfrog.artifactory.client.model.impl.RemoteReplicationImpl
 
 class RemoteReplicationBuilderImpl extends ReplicationBuilderBase<RemoteReplicationBuilder> {
 
+    RemoteReplicationBuilderImpl() {
+    }
+
+    RemoteReplicationBuilderImpl(RemoteReplication replication) {
+        super(replication);
+    }
+
     RemoteReplication build() {
         new RemoteReplicationImpl(enabled, cronExp, syncDeletes, syncProperties, repoKey);
     }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/ReplicationBuilderBase.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/ReplicationBuilderBase.groovy
@@ -1,0 +1,51 @@
+package org.jfrog.artifactory.client.model.builder.impl
+
+import org.jfrog.artifactory.client.model.builder.ReplicationBuilder
+
+abstract class ReplicationBuilderBase<B extends ReplicationBuilder> implements ReplicationBuilder<B> {
+
+    protected boolean enabled;
+
+    protected String cronExp;
+
+    protected boolean syncDeletes;
+
+    protected boolean syncProperties;
+
+    protected String repoKey;
+
+    @Override
+    B enabled(boolean enabled) {
+        this.enabled = enabled;
+
+        return this;
+    }
+
+    @Override
+    B cronExp(String cronExp) {
+        this.cronExp = cronExp;
+
+        return this;
+    }
+
+    @Override
+    B syncDeletes(boolean syncDeletes) {
+        this.syncDeletes = syncDeletes;
+
+        return this;
+    }
+
+    @Override
+    B syncProperties(boolean syncProperties) {
+        this.syncProperties = syncProperties;
+
+        return this;
+    }
+
+    @Override
+    B repoKey(String repoKey) {
+        this.repoKey = repoKey;
+
+        return this;
+    }
+}

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/ReplicationBuilderBase.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/ReplicationBuilderBase.groovy
@@ -1,5 +1,6 @@
 package org.jfrog.artifactory.client.model.builder.impl
 
+import org.jfrog.artifactory.client.model.Replication
 import org.jfrog.artifactory.client.model.builder.ReplicationBuilder
 
 abstract class ReplicationBuilderBase<B extends ReplicationBuilder> implements ReplicationBuilder<B> {
@@ -13,6 +14,21 @@ abstract class ReplicationBuilderBase<B extends ReplicationBuilder> implements R
     protected boolean syncProperties;
 
     protected String repoKey;
+
+    protected ReplicationBuilderBase() {
+    }
+
+    protected ReplicationBuilderBase(Replication replication) {
+        if (!replication) {
+            throw new IllegalArgumentException("The given replication is null")
+        }
+
+        this.enabled = replication.enabled;
+        this.cronExp = replication.cronExp;
+        this.syncDeletes = replication.syncDeletes;
+        this.syncProperties = replication.syncProperties;
+        this.repoKey = replication.repoKey;
+    }
 
     @Override
     B enabled(boolean enabled) {

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalReplicationImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalReplicationImpl.java
@@ -17,7 +17,7 @@ public class LocalReplicationImpl implements LocalReplication {
     private String pathPrefix;
     private String repoKey;
 
-    public LocalReplicationImpl() {
+    LocalReplicationImpl() {
     }
 
     LocalReplicationImpl(String url, long socketTimeoutMillis, String username, String password,

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/RemoteReplicationImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/RemoteReplicationImpl.java
@@ -10,9 +10,6 @@ public class RemoteReplicationImpl implements RemoteReplication {
     private boolean syncProperties;
     private String repoKey;
 
-    public RemoteReplicationImpl() {
-    }
-
     RemoteReplicationImpl(boolean enabled, String cronExp, boolean syncDeletes, boolean syncProperties, String repoKey) {
         this.enabled = enabled;
         this.cronExp = cronExp;

--- a/services/src/main/resources/artifactory.client.release.properties
+++ b/services/src/main/resources/artifactory.client.release.properties
@@ -1,1 +1,1 @@
-version=2.5.2
+version=2.5.x-SNAPSHOT


### PR DESCRIPTION
This PR is an add-on to PR #126.

It adds builder classes so that users can easily build instances of LocalReplication and RemoteReplication.

The initial PR was missing those builders because the code I used for validating the (Java-based) API was written in Groovy and hid the fact that the LocalReplicationImpl and RemoteReplicationImpl had their properties private.