### PR TITLE
Fix Authorization header concatenation error

### DIFF
--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ArtifactoryImpl.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ArtifactoryImpl.java
@@ -242,7 +242,7 @@ public class ArtifactoryImpl implements Artifactory {
 
     private HttpRequestBase addAccessTokenHeaderIfNeeded(HttpRequestBase httpRequestBase) {
         if (StringUtils.isNotEmpty(accessToken)) {
-            httpRequestBase.addHeader("Authorization", "Bearer $accessToken");
+            httpRequestBase.addHeader("Authorization", "Bearer " + accessToken);
         }
         return httpRequestBase;
     }


### PR DESCRIPTION
Authorization header concatenation missed when moving from Groovy to Java