### PR TITLE
Rename repoLayoutRef in RepositorySettings

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/model/builder/RepositoryBuilder.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/builder/RepositoryBuilder.java
@@ -37,7 +37,9 @@ public interface RepositoryBuilder<B extends RepositoryBuilder, R extends Reposi
 
     void validate();
 
-    void setRepoLayout();
+    B repoLayoutRef(String repoLayoutRef);
+
+    void setRepoLayoutFromSettings();
 
     B repositorySettings(RepositorySettings settings);
 

--- a/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/AbstractRepositorySettings.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/AbstractRepositorySettings.java
@@ -4,13 +4,17 @@ package org.jfrog.artifactory.client.model.repository.settings;
  * @author Lior Hasson
  */
 public abstract class AbstractRepositorySettings implements RepositorySettings {
-    protected String repoLayoutRef;
+    private String repoLayout;
+
+    public AbstractRepositorySettings(String repoLayout) {
+        this.repoLayout = repoLayout;
+    }
 
     public String getRepoLayout() {
-        return this.repoLayoutRef;
+        return this.repoLayout;
     }
 
     public void setRepoLayout(String repoLayout) {
-        this.repoLayoutRef = repoLayout;
+        this.repoLayout = repoLayout;
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-currentVersion=2.5.2
+currentVersion=2.5.x-SNAPSHOT

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/jackson/RepositorySettingsMixIn.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/jackson/RepositorySettingsMixIn.java
@@ -1,9 +1,34 @@
 package org.jfrog.artifactory.client.impl.jackson;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings;
-import org.jfrog.artifactory.client.model.repository.settings.impl.*;
+import org.jfrog.artifactory.client.model.repository.settings.impl.BowerRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.ChefRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.CocoaPodsRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.ComposerRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.ConanRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.DebianRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.DockerRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.GemsRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.GenericRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.GitLfsRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.GradleRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.IvyRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.MavenRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.NpmRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.NugetRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.OpkgRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.P2RepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.PuppetRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.PypiRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.RpmRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.SbtRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.VagrantRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.VcsRepositorySettingsImpl;
+import org.jfrog.artifactory.client.model.repository.settings.impl.YumRepositorySettingsImpl;
 
 /**
  * special serialization / deserialization handling for {@link RepositorySettings}
@@ -37,6 +62,8 @@ import org.jfrog.artifactory.client.model.repository.settings.impl.*;
     @JsonSubTypes.Type(value = ChefRepositorySettingsImpl.class, name = "chef"),
     @JsonSubTypes.Type(value = PuppetRepositorySettingsImpl.class, name = "puppet")
 })
-public interface RepositorySettingsMixIn {
 
+public abstract class RepositorySettingsMixIn {
+  @JsonIgnore
+  abstract String getRepoLayout();
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalRepositoryBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/LocalRepositoryBuilderImpl.groovy
@@ -22,7 +22,7 @@ class LocalRepositoryBuilderImpl extends NonVirtualRepositoryBuilderBase<LocalRe
 
     LocalRepository build() {
         validate()
-        setRepoLayout()
+        setRepoLayoutFromSettings()
 
         return new LocalRepositoryImpl(key, settings, xraySettings, description, excludesPattern,
             includesPattern, notes, blackedOut,

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteRepositoryBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteRepositoryBuilderImpl.groovy
@@ -276,7 +276,7 @@ class RemoteRepositoryBuilderImpl extends NonVirtualRepositoryBuilderBase<Remote
     @SuppressWarnings("GroovyAccessibility")
     RemoteRepository build() {
         validate()
-        setRepoLayout()
+        setRepoLayoutFromSettings()
 
         new RemoteRepositoryImpl(key, settings, xraySettings, contentSync, description, excludesPattern,
                 includesPattern, notes, blackedOut, propertySets, failedRetrievalCachePeriodSecs,

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuilderBase.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RepositoryBuilderBase.groovy
@@ -123,12 +123,18 @@ abstract class RepositoryBuilderBase<B extends RepositoryBuilder, R extends Repo
         }
         if (this.settings != null && !settings.packageType.isCustom()
             && !supportedTypes.contains(settings.packageType)) {
-            throw new IllegalArgumentException("Package type '${settings.packageType}' is not supported in $repositoryType repositories");
+            throw new IllegalArgumentException("Package type '${settings.packageType}' is not supported in $repositoryType repositories")
         }
     }
 
     @Override
-    void setRepoLayout() {
+    B repoLayoutRef(String repoLayoutRef) {
+        this.repoLayoutRef = repoLayoutRef
+        this as B
+    }
+
+    @Override
+    void setRepoLayoutFromSettings() {
         if (this.repoLayoutRef == null && settings != null) {
             this.repoLayoutRef = settings.getRepoLayout()
         }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/VirtualRepositoryBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/VirtualRepositoryBuilderImpl.groovy
@@ -56,7 +56,7 @@ class VirtualRepositoryBuilderImpl extends RepositoryBuilderBase<VirtualReposito
 
     VirtualRepository build() {
         validate()
-        setRepoLayout()
+        setRepoLayoutFromSettings()
 
         new VirtualRepositoryImpl(key, settings, description, excludesPattern,
             includesPattern, notes, artifactoryRequestsCanRetrieveRemoteArtifacts,

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/BowerRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/BowerRepositorySettingsImpl.groovy
@@ -19,12 +19,12 @@ class BowerRepositorySettingsImpl extends VcsRepositorySettingsImpl implements B
     Collection<String> externalDependenciesPatterns
     String externalDependenciesRemoteRepo
 
-    public BowerRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+    BowerRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.bower
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ChefRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ChefRepositorySettingsImpl.groovy
@@ -10,8 +10,8 @@ import org.jfrog.artifactory.client.model.repository.settings.ChefRepositorySett
 class ChefRepositorySettingsImpl extends AbstractRepositorySettings implements ChefRepositorySettings {
     static defaultLayout = "simple-default"
 
-    public ChefRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  ChefRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/CocoaPodsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/CocoaPodsRepositorySettingsImpl.groovy
@@ -16,12 +16,12 @@ class CocoaPodsRepositorySettingsImpl extends VcsRepositorySettingsImpl implemen
 
     String podsSpecsRepoUrl
 
-    public CocoaPodsRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  CocoaPodsRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.cocoapods
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ComposerRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ComposerRepositorySettingsImpl.groovy
@@ -11,8 +11,8 @@ class ComposerRepositorySettingsImpl extends VcsRepositorySettingsImpl implement
 
     String composerRegistryUrl
 
-    public ComposerRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  ComposerRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ConanRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/ConanRepositorySettingsImpl.groovy
@@ -10,8 +10,8 @@ import org.jfrog.artifactory.client.model.repository.settings.ConanRepositorySet
 class ConanRepositorySettingsImpl extends AbstractRepositorySettings implements ConanRepositorySettings {
     static String defaultLayout = "conan-default"
 
-    public ConanRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  ConanRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DebianRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DebianRepositorySettingsImpl.groovy
@@ -18,12 +18,12 @@ class DebianRepositorySettingsImpl extends AbstractRepositorySettings implements
     Boolean debianTrivialLayout
     Boolean listRemoteFolderItems
 
-    public DebianRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  DebianRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.debian
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.groovy
@@ -13,7 +13,7 @@ import org.jfrog.artifactory.client.model.repository.settings.docker.DockerApiVe
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 @EqualsAndHashCode
-public class DockerRepositorySettingsImpl extends AbstractRepositorySettings implements DockerRepositorySettings{
+class DockerRepositorySettingsImpl extends AbstractRepositorySettings implements DockerRepositorySettings{
     static String defaultLayout = "simple-default"
 
     DockerApiVersion dockerApiVersion
@@ -21,12 +21,12 @@ public class DockerRepositorySettingsImpl extends AbstractRepositorySettings imp
     Boolean listRemoteFolderItems
     Integer maxUniqueTags
 
-    public DockerRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  DockerRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.docker
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GemsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GemsRepositorySettingsImpl.groovy
@@ -17,12 +17,12 @@ class GemsRepositorySettingsImpl extends AbstractRepositorySettings implements G
 
     Boolean listRemoteFolderItems
 
-    public GemsRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  GemsRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.gems
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GenericRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GenericRepositorySettingsImpl.groovy
@@ -17,12 +17,12 @@ class GenericRepositorySettingsImpl extends AbstractRepositorySettings implement
 
     Boolean listRemoteFolderItems
 
-    public GenericRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  GenericRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.generic
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GitLfsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GitLfsRepositorySettingsImpl.groovy
@@ -17,12 +17,12 @@ class GitLfsRepositorySettingsImpl extends AbstractRepositorySettings implements
 
     Boolean listRemoteFolderItems
 
-    public GitLfsRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  GitLfsRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.gitlfs
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GradleRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/GradleRepositorySettingsImpl.groovy
@@ -15,16 +15,11 @@ class GradleRepositorySettingsImpl extends MavenRepositorySettingsImpl implement
     static String defaultLayout = "gradle-default"
 
     GradleRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.gradle
-    }
-
-    @Override
-    public String getRepoLayout() {
-        return this.repoLayoutRef
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/IvyRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/IvyRepositorySettingsImpl.groovy
@@ -14,12 +14,12 @@ import org.jfrog.artifactory.client.model.repository.settings.IvyRepositorySetti
 class IvyRepositorySettingsImpl extends MavenRepositorySettingsImpl implements IvyRepositorySettings {
     static String defaultLayout = "ivy-default"
 
-    public IvyRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  IvyRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.ivy
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/MavenRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/MavenRepositorySettingsImpl.groovy
@@ -33,12 +33,16 @@ class MavenRepositorySettingsImpl extends AbstractRepositorySettings implements 
     PomCleanupPolicy pomRepositoryReferencesCleanupPolicy
     String keyPair
 
-    public MavenRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+    MavenRepositorySettingsImpl() {
+        this(defaultLayout)
+    }
+
+    MavenRepositorySettingsImpl(String repoLayout) {
+        super(repoLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.maven
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NpmRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NpmRepositorySettingsImpl.groovy
@@ -20,12 +20,12 @@ class NpmRepositorySettingsImpl extends AbstractRepositorySettings implements Np
     Collection<String> externalDependenciesPatterns
     String externalDependenciesRemoteRepo
 
-    public NpmRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  NpmRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.npm
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NugetRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/NugetRepositorySettingsImpl.groovy
@@ -21,12 +21,12 @@ class NugetRepositorySettingsImpl extends AbstractRepositorySettings implements 
     String downloadContextPath
     Boolean listRemoteFolderItems
 
-    public NugetRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  NugetRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.nuget
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/OpkgRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/OpkgRepositorySettingsImpl.groovy
@@ -17,12 +17,12 @@ class OpkgRepositorySettingsImpl extends AbstractRepositorySettings implements O
 
     Boolean listRemoteFolderItems
 
-    public OpkgRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  OpkgRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.opkg
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/P2RepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/P2RepositorySettingsImpl.groovy
@@ -12,12 +12,9 @@ import org.jfrog.artifactory.client.model.repository.settings.P2RepositorySettin
  */
 @EqualsAndHashCode
 class P2RepositorySettingsImpl extends MavenRepositorySettingsImpl implements P2RepositorySettings {
-    public P2RepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
-    }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.p2
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PuppetRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PuppetRepositorySettingsImpl.groovy
@@ -10,8 +10,8 @@ import org.jfrog.artifactory.client.model.repository.settings.PuppetRepositorySe
 class PuppetRepositorySettingsImpl extends AbstractRepositorySettings implements PuppetRepositorySettings {
     static String defaultLayout = "puppet-default"
 
-    public PuppetRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  PuppetRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PypiRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/PypiRepositorySettingsImpl.groovy
@@ -17,12 +17,12 @@ class PypiRepositorySettingsImpl extends AbstractRepositorySettings implements P
 
     Boolean listRemoteFolderItems
 
-    public PypiRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  PypiRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.pypi
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/RpmRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/RpmRepositorySettingsImpl.groovy
@@ -21,12 +21,12 @@ class RpmRepositorySettingsImpl extends AbstractRepositorySettings implements Rp
     Boolean enableFileListsIndexing
     Boolean listRemoteFolderItems
 
-    public RpmRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+  RpmRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.rpm
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/SbtRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/SbtRepositorySettingsImpl.groovy
@@ -14,12 +14,12 @@ import org.jfrog.artifactory.client.model.repository.settings.SbtRepositorySetti
 class SbtRepositorySettingsImpl extends MavenRepositorySettingsImpl implements SbtRepositorySettings {
     static String defaultLayout = "sbt-default"
 
-    public SbtRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+    SbtRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.sbt
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VagrantRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VagrantRepositorySettingsImpl.groovy
@@ -15,12 +15,12 @@ import org.jfrog.artifactory.client.model.repository.settings.VagrantRepositoryS
 class VagrantRepositorySettingsImpl extends AbstractRepositorySettings implements VagrantRepositorySettings {
     static String defaultLayout = "simple-default"
 
-    public VagrantRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+    VagrantRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.vagrant
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VcsRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/VcsRepositorySettingsImpl.groovy
@@ -23,12 +23,16 @@ class VcsRepositorySettingsImpl extends AbstractRepositorySettings implements Vc
     String vcsGitDownloadUrl
     Boolean listRemoteFolderItems
 
-    public VcsRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+    VcsRepositorySettingsImpl() {
+        this(defaultLayout)
+    }
+
+    VcsRepositorySettingsImpl(String repoLayout){
+        super(repoLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.vcs
     }
 }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/YumRepositorySettingsImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/repository/settings/impl/YumRepositorySettingsImpl.groovy
@@ -23,12 +23,12 @@ class YumRepositorySettingsImpl extends AbstractRepositorySettings implements Yu
     Boolean calculateYumMetadata
     Boolean listRemoteFolderItems
 
-    public YumRepositorySettingsImpl() {
-        this.repoLayoutRef = defaultLayout
+    YumRepositorySettingsImpl() {
+        super(defaultLayout)
     }
 
     @Override
-    public PackageType getPackageType() {
+    PackageType getPackageType() {
         return PackageTypeImpl.yum
     }
 }

--- a/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/CustomRepositorySettingsImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/CustomRepositorySettingsImpl.java
@@ -6,13 +6,13 @@ import org.jfrog.artifactory.client.model.repository.settings.AbstractRepository
 import org.jfrog.artifactory.client.model.repository.settings.CustomRepositorySettings;
 
 public class CustomRepositorySettingsImpl extends AbstractRepositorySettings implements CustomRepositorySettings {
-    public static String defaultLayout = "maven-2-default";
+    private static final String DEFAULT_LAYOUT = "maven-2-default";
 
     private PackageType packageType;
 
     public CustomRepositorySettingsImpl(CustomPackageTypeImpl packageType) {
+        super(DEFAULT_LAYOUT);
         this.packageType = packageType;
-        this.repoLayoutRef = defaultLayout;
     }
 
     @Override

--- a/services/src/test/groovy/org/jfrog/artifactory/client/BaseRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/BaseRepositoryTests.groovy
@@ -1,4 +1,4 @@
-package org.jfrog.artifactory.client;
+package org.jfrog.artifactory.client
 
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -17,7 +17,7 @@ import org.testng.annotations.BeforeMethod
 /**
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
-public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
+abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
 
     /**
      * used to generate test values ( especially boolean ones ) to be sure that we are sending
@@ -45,7 +45,7 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
         if (prepareGenericRepo) {
             RepositorySettings settings = getRepositorySettings(RepositoryTypeImpl.LOCAL)
 
-            XraySettings genericXraySettings = new XraySettingsImpl();
+            XraySettings genericXraySettings = new XraySettingsImpl()
             genericRepo = artifactory.repositories().builders().localRepositoryBuilder()
                     .key("cutsman-repo_${rnd.nextInt()}")
                     .description("description_${rnd.nextInt()}")
@@ -79,7 +79,7 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
 
         if (prepareRemoteRepo) {
             RepositorySettings settings = getRepositorySettings()
-            ContentSync contentSync = new ContentSyncImpl();
+            ContentSync contentSync = new ContentSyncImpl()
             remoteRepo = artifactory.repositories().builders().remoteRepositoryBuilder()
                 .key("cutsman-repo_${rnd.nextInt()}")
                 .description("description_${rnd.nextInt()}")


### PR DESCRIPTION
Because of the new `repoLayout` in `RepositorySettings`, the rest call to Artifactory sends both `repoLayoutRef` and `repoLayout`. This pull request changes the name of the attribute `repoLayoutRef` to `repoLayout` to match the names of the getters/setters, adds `@JsonIgnore` to `getRepoLayout()` to eliminate the duplication, and add the `repoLayoutRef` setter back to `RepositoryBuilderBase`.