### PR TITLE
Correct default repo type for remote repositories

### DIFF
--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteRepositoryBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteRepositoryBuilderImpl.groovy
@@ -7,7 +7,6 @@ import org.jfrog.artifactory.client.model.builder.RemoteRepositoryBuilder
 import org.jfrog.artifactory.client.model.impl.RemoteRepositoryImpl
 import org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl
 
-import static org.jfrog.artifactory.client.model.Repository.MAVEN_2_REPO_LAYOUT
 import static org.jfrog.artifactory.client.model.impl.PackageTypeImpl.*
 
 /**

--- a/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteRepositoryBuilderImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/model/builder/impl/RemoteRepositoryBuilderImpl.groovy
@@ -20,7 +20,6 @@ class RemoteRepositoryBuilderImpl extends NonVirtualRepositoryBuilderBase<Remote
     RemoteRepositoryBuilderImpl() {
         super([bower, cocoapods, debian, docker, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, opkg, p2,
                pypi, sbt, vcs, yum, rpm, composer, conan, chef, puppet] as Set)
-        repoLayoutRef = MAVEN_2_REPO_LAYOUT
     }
 
     private String url

--- a/services/src/test/groovy/org/jfrog/artifactory/client/BaseRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/BaseRepositoryTests.groovy
@@ -44,7 +44,6 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
     protected void setUp() {
         if (prepareGenericRepo) {
             RepositorySettings settings = getRepositorySettings(RepositoryTypeImpl.LOCAL)
-            settings?.repoLayout = "maven-2-default"
 
             XraySettings genericXraySettings = new XraySettingsImpl();
             genericRepo = artifactory.repositories().builders().localRepositoryBuilder()
@@ -63,7 +62,6 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
         }
         if (prepareLocalRepo) {
             RepositorySettings settings = getRepositorySettings()
-            settings?.repoLayout = "maven-2-default"
             localRepo = artifactory.repositories().builders().localRepositoryBuilder()
                 .key("cutsman-repo_${rnd.nextInt()}")
                 .description("description_${rnd.nextInt()}")
@@ -81,7 +79,6 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
 
         if (prepareRemoteRepo) {
             RepositorySettings settings = getRepositorySettings()
-            settings?.repoLayout = "maven-2-default"
             ContentSync contentSync = new ContentSyncImpl();
             remoteRepo = artifactory.repositories().builders().remoteRepositoryBuilder()
                 .key("cutsman-repo_${rnd.nextInt()}")
@@ -122,7 +119,6 @@ public abstract class BaseRepositoryTests extends ArtifactoryTestsBase {
 
         if (prepareVirtualRepo) {
             RepositorySettings settings = getRepositorySettings()
-            settings?.repoLayout = "maven-2-default"
             artifactory.repositories().create(0, genericRepo)
             def repos = new ArrayList<String>()
             repos.add(genericRepo.getKey())

--- a/services/src/test/groovy/org/jfrog/artifactory/client/BowerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/BowerPackageTypeRepositoryTests.groovy
@@ -50,8 +50,11 @@ public class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(BowerRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
@@ -74,8 +77,11 @@ public class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(BowerRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
@@ -98,8 +104,11 @@ public class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(BowerRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ChefPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ChefPackageTypeRepositoryTests.groovy
@@ -28,8 +28,11 @@ public class ChefPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(ChefRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 
@@ -39,8 +42,11 @@ public class ChefPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(ChefRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 
@@ -50,8 +56,11 @@ public class ChefPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(ChefRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/CocoaPodsPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/CocoaPodsPackageTypeRepositoryTests.groovy
@@ -1,7 +1,7 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.CocoaPodsRepositorySettingsImpl
 import org.jfrog.artifactory.client.model.repository.settings.vcs.VcsGitProvider
@@ -47,8 +47,11 @@ public class CocoaPodsPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(CocoaPodsRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
@@ -66,8 +69,11 @@ public class CocoaPodsPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(CocoaPodsRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ComposerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ComposerPackageTypeRepositoryTests.groovy
@@ -42,8 +42,11 @@ public class ComposerPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(ComposerRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
@@ -61,8 +64,11 @@ public class ComposerPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(ComposerRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
@@ -80,8 +86,11 @@ public class ComposerPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(ComposerRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ConanPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ConanPackageTypeRepositoryTests.groovy
@@ -27,8 +27,11 @@ public class ConanPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(ConanRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 
@@ -38,8 +41,11 @@ public class ConanPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(ConanRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 
@@ -49,8 +55,11 @@ public class ConanPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(ConanRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/CustomPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/CustomPackageTypeRepositoryTests.groovy
@@ -6,6 +6,7 @@ import org.jfrog.artifactory.client.model.impl.CustomPackageTypeImpl
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
 import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.CustomRepositorySettingsImpl
+import org.jfrog.artifactory.client.model.repository.settings.impl.RpmRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
@@ -19,7 +20,9 @@ class CustomPackageTypeRepositoryTests extends BaseRepositoryTests {
     @Override
     RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
         CustomPackageTypeImpl customPackageType = new CustomPackageTypeImpl("rpm")
-        return new CustomRepositorySettingsImpl(customPackageType)
+        CustomRepositorySettingsImpl repositorySettings = new CustomRepositorySettingsImpl(customPackageType)
+        repositorySettings.setRepoLayout(RpmRepositorySettingsImpl.defaultLayout)
+        return repositorySettings
     }
 
     @BeforeMethod
@@ -45,8 +48,11 @@ class CustomPackageTypeRepositoryTests extends BaseRepositoryTests {
         artifactory.repositories().create(0, localRepo)
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(PackageTypeImpl.rpm))
+            assertThat(repoLayout, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
 
             // local
             assertThat(calculateYumMetadata, CoreMatchers.is(someCalculateYumMetadata))
@@ -63,8 +69,11 @@ class CustomPackageTypeRepositoryTests extends BaseRepositoryTests {
         artifactory.repositories().create(0, remoteRepo)
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(PackageTypeImpl.rpm))
+            assertThat(repoLayout, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(someListRemoteFolderItems))
@@ -81,8 +90,11 @@ class CustomPackageTypeRepositoryTests extends BaseRepositoryTests {
         artifactory.repositories().create(0, virtualRepo)
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(PackageTypeImpl.rpm))
+            assertThat(repoLayout, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
 
             // local
             assertThat(calculateYumMetadata, CoreMatchers.is(CoreMatchers.nullValue()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/DebianPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/DebianPackageTypeRepositoryTests.groovy
@@ -1,7 +1,7 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.DebianRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
@@ -43,8 +43,11 @@ public class DebianPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(DebianRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(debianTrivialLayout, CoreMatchers.is(expectedSettings.getDebianTrivialLayout()))
@@ -60,8 +63,11 @@ public class DebianPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(DebianRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(debianTrivialLayout, CoreMatchers.is(Boolean.FALSE)) // always in resp payload

--- a/services/src/test/groovy/org/jfrog/artifactory/client/DockerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/DockerPackageTypeRepositoryTests.groovy
@@ -42,8 +42,11 @@ public class DockerPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(DockerRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion()))
@@ -60,8 +63,11 @@ public class DockerPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(DockerRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion())) // always in resp payload
@@ -78,8 +84,11 @@ public class DockerPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(DockerRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GemsPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GemsPackageTypeRepositoryTests.groovy
@@ -37,8 +37,11 @@ public class GemsPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GemsRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -49,8 +52,11 @@ public class GemsPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GemsRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
@@ -61,8 +67,11 @@ public class GemsPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GemsRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GeneralRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GeneralRepositoryTests.groovy
@@ -8,7 +8,7 @@ import org.jfrog.artifactory.client.model.repository.settings.impl.GenericReposi
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
-import static org.testng.Assert.*
+import static org.testng.Assert.assertTrue
 
 /**
  * test that client correctly sends and receives general repository configuration
@@ -33,6 +33,7 @@ public class GeneralRepositoryTests extends BaseRepositoryTests {
         assertTrue(curl(LIST_PATH).contains(localRepo.getKey()))
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
         resp.with {
             assertThat(rclass, CoreMatchers.is(RepositoryTypeImpl.LOCAL))
             assertThat(key, CoreMatchers.is(localRepo.getKey()))
@@ -43,7 +44,7 @@ public class GeneralRepositoryTests extends BaseRepositoryTests {
             assertThat(excludesPattern, CoreMatchers.is(localRepo.getExcludesPattern()))
             assertThat(includesPattern, CoreMatchers.is(localRepo.getIncludesPattern()))
             assertThat(propertySets, CoreMatchers.is(localRepo.getPropertySets()))
-            assertThat(localRepo.getRepoLayoutRef(), CoreMatchers.is(localRepo.getRepoLayoutRef()))
+            assertThat(repoLayoutRef, CoreMatchers.is(localRepo.getRepoLayoutRef()))
         }
     }
 
@@ -53,6 +54,7 @@ public class GeneralRepositoryTests extends BaseRepositoryTests {
         assertTrue(curl(LIST_PATH).contains(remoteRepo.getKey()))
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
         resp.with {
             assertThat(rclass, CoreMatchers.is(RepositoryTypeImpl.REMOTE))
             assertThat(key, CoreMatchers.is(remoteRepo.getKey()))
@@ -70,7 +72,7 @@ public class GeneralRepositoryTests extends BaseRepositoryTests {
             assertThat(offline, CoreMatchers.is(remoteRepo.isOffline()))
             assertThat(propertySets, CoreMatchers.is(remoteRepo.getPropertySets()))
             assertThat(proxy, CoreMatchers.is(remoteRepo.getProxy()))
-            assertThat(remoteRepo.getRepoLayoutRef(), CoreMatchers.is(remoteRepo.getRepoLayoutRef()))
+            assertThat(repoLayoutRef, CoreMatchers.is(remoteRepo.getRepoLayoutRef()))
             assertThat(retrievalCachePeriodSecs, CoreMatchers.is(remoteRepo.getRetrievalCachePeriodSecs()))
             assertThat(shareConfiguration, CoreMatchers.is(remoteRepo.isShareConfiguration()))
             assertThat(socketTimeoutMillis, CoreMatchers.is(remoteRepo.getSocketTimeoutMillis()))
@@ -88,6 +90,7 @@ public class GeneralRepositoryTests extends BaseRepositoryTests {
         assertTrue(curl(LIST_PATH).contains(virtualRepo.getKey()))
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
         resp.with {
             assertThat(rclass, CoreMatchers.is(RepositoryTypeImpl.VIRTUAL))
             assertThat(key, CoreMatchers.is(virtualRepo.getKey()))
@@ -99,7 +102,7 @@ public class GeneralRepositoryTests extends BaseRepositoryTests {
             assertThat(virtualRepo.getRepoLayoutRef(), CoreMatchers.is(virtualRepo.getRepoLayoutRef()))
             assertThat(repositories.last(), CoreMatchers.is(virtualRepo.getRepositories().last()))
             assertThat(defaultDeploymentRepo, CoreMatchers.is(virtualRepo.getDefaultDeploymentRepo()))
+            assertThat(repoLayoutRef, CoreMatchers.is(remoteRepo.getRepoLayoutRef()))
         }
     }
-
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GenericPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GenericPackageTypeRepositoryTests.groovy
@@ -37,8 +37,11 @@ public class GenericPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GenericRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -49,8 +52,11 @@ public class GenericPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GenericRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
@@ -61,8 +67,11 @@ public class GenericPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GenericRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GitLfsPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GitLfsPackageTypeRepositoryTests.groovy
@@ -37,8 +37,11 @@ public class GitLfsPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GitLfsRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -49,8 +52,11 @@ public class GitLfsPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GitLfsRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
@@ -61,8 +67,11 @@ public class GitLfsPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GitLfsRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GradlePackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GradlePackageTypeRepositoryTests.groovy
@@ -57,8 +57,11 @@ public class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GradleRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.is(expectedSettings.getChecksumPolicyType()))
@@ -87,8 +90,11 @@ public class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GradleRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -120,8 +126,11 @@ public class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(GradleRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())

--- a/services/src/test/groovy/org/jfrog/artifactory/client/IvyPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/IvyPackageTypeRepositoryTests.groovy
@@ -57,8 +57,11 @@ public class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(IvyRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.is(expectedSettings.getChecksumPolicyType()))
@@ -87,8 +90,11 @@ public class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(IvyRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -120,8 +126,11 @@ public class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(IvyRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())

--- a/services/src/test/groovy/org/jfrog/artifactory/client/MavenPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/MavenPackageTypeRepositoryTests.groovy
@@ -1,7 +1,7 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.LocalRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.RemoteRepoChecksumPolicyTypeImpl
 import org.jfrog.artifactory.client.model.impl.SnapshotVersionBehaviorImpl
@@ -57,8 +57,11 @@ public class MavenPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(MavenRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.is(expectedSettings.getChecksumPolicyType()))
@@ -87,8 +90,11 @@ public class MavenPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(MavenRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -119,8 +125,11 @@ public class MavenPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(MavenRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())

--- a/services/src/test/groovy/org/jfrog/artifactory/client/NpmPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/NpmPackageTypeRepositoryTests.groovy
@@ -43,8 +43,12 @@ public class NpmPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(NpmRepositorySettingsImpl.defaultLayout))
+
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
@@ -62,8 +66,11 @@ public class NpmPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(NpmRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
@@ -81,8 +88,11 @@ public class NpmPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(NpmRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())

--- a/services/src/test/groovy/org/jfrog/artifactory/client/NugetPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/NugetPackageTypeRepositoryTests.groovy
@@ -45,8 +45,11 @@ public class NugetPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(NugetRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
@@ -71,8 +74,11 @@ public class NugetPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(NugetRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
@@ -94,8 +100,11 @@ public class NugetPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(NugetRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(maxUniqueSnapshots, CoreMatchers.is(CoreMatchers.nullValue())) // always in resp payload

--- a/services/src/test/groovy/org/jfrog/artifactory/client/OpkgPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/OpkgPackageTypeRepositoryTests.groovy
@@ -40,8 +40,11 @@ public class OpkgPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(OpkgRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -52,8 +55,11 @@ public class OpkgPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(OpkgRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/P2PackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/P2PackageTypeRepositoryTests.groovy
@@ -65,8 +65,11 @@ public class P2PackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(P2RepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -98,8 +101,11 @@ public class P2PackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(P2RepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())

--- a/services/src/test/groovy/org/jfrog/artifactory/client/PuppetPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/PuppetPackageTypeRepositoryTests.groovy
@@ -28,8 +28,11 @@ public class PuppetPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(PuppetRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 
@@ -39,8 +42,11 @@ public class PuppetPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(PuppetRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 
@@ -50,8 +56,11 @@ public class PuppetPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(PuppetRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/PypiPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/PypiPackageTypeRepositoryTests.groovy
@@ -1,7 +1,7 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.PypiRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
@@ -38,6 +38,7 @@ public class PypiPackageTypeRepositoryTests extends BaseRepositoryTests {
         def resp = artifactory.repository(localRepo.getKey()).get()
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }
@@ -48,8 +49,11 @@ public class PypiPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(PypiRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
         }
     }
@@ -60,8 +64,11 @@ public class PypiPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(PypiRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
             assertThat(listRemoteFolderItems, CoreMatchers.nullValue())
         }
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/RpmPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/RpmPackageTypeRepositoryTests.groovy
@@ -46,8 +46,11 @@ public class RpmPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(calculateYumMetadata, CoreMatchers.is(expectedSettings.getCalculateYumMetadata()))
@@ -68,8 +71,11 @@ public class RpmPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/SbtPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/SbtPackageTypeRepositoryTests.groovy
@@ -57,8 +57,11 @@ public class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(SbtRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.is(expectedSettings.getChecksumPolicyType()))
@@ -87,8 +90,11 @@ public class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(SbtRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
@@ -120,8 +126,11 @@ public class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = virtualRepo.repositorySettings
 
         def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(SbtRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(checksumPolicyType, CoreMatchers.nullValue())

--- a/services/src/test/groovy/org/jfrog/artifactory/client/VagrantPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/VagrantPackageTypeRepositoryTests.groovy
@@ -1,7 +1,7 @@
 package org.jfrog.artifactory.client
 
 import org.hamcrest.CoreMatchers
-import org.jfrog.artifactory.client.model.*
+import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
 import org.jfrog.artifactory.client.model.repository.settings.impl.VagrantRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
@@ -34,8 +34,11 @@ public class VagrantPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(VagrantRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
         }
     }
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/VcsPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/VcsPackageTypeRepositoryTests.groovy
@@ -51,8 +51,11 @@ public class VcsPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(VcsRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(vcsGitDownloadUrl, CoreMatchers.is(expectedSettings.getVcsGitDownloadUrl()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/YumPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/YumPackageTypeRepositoryTests.groovy
@@ -4,6 +4,7 @@ import org.hamcrest.CoreMatchers
 import org.jfrog.artifactory.client.model.RepositoryType
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
 import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
+import org.jfrog.artifactory.client.model.repository.settings.impl.RpmRepositorySettingsImpl
 import org.jfrog.artifactory.client.model.repository.settings.impl.YumRepositorySettingsImpl
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -46,9 +47,12 @@ public class YumPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = localRepo.repositorySettings
 
         def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             // The package type is 'rpm' since Artifactory 5.0.0
             assertThat(packageType, CoreMatchers.is(PackageTypeImpl.rpm))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // local
             assertThat(calculateYumMetadata, CoreMatchers.is(expectedSettings.getCalculateYumMetadata()))
@@ -68,9 +72,12 @@ public class YumPackageTypeRepositoryTests extends BaseRepositoryTests {
         def expectedSettings = remoteRepo.repositorySettings
 
         def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(RpmRepositorySettingsImpl.defaultLayout))
         resp.getRepositorySettings().with {
             // The package type is 'rpm' since Artifactory 5.0.0
             assertThat(packageType, CoreMatchers.is(PackageTypeImpl.rpm))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))


### PR DESCRIPTION
`maven-2-default` was used for remote repositories.