### PR TITLE
adding "application/jose+json" content type option

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/ArtifactoryRequest.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/ArtifactoryRequest.java
@@ -30,6 +30,7 @@ public interface ArtifactoryRequest {
 
     enum ContentType {
         JSON("JSON"),
+        JWS("JWS"),
         TEXT("TEXT"),
         URLENC("URLENC"),
         ANY("ANY");

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/util/Util.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/util/Util.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.Consts;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.jfrog.artifactory.client.ArtifactoryRequest;
@@ -83,6 +84,10 @@ public class Util {
 
         if (contentType.equals(ArtifactoryRequest.ContentType.JSON)) {
             return ContentType.APPLICATION_JSON;
+        }
+
+        if (contentType.equals(ArtifactoryRequest.ContentType.JSON)) {
+            return ContentType.create("application/jose+json", Consts.ISO_8859_1);
         }
 
         if (contentType.equals(ArtifactoryRequest.ContentType.TEXT)) {


### PR DESCRIPTION
Added JWS content-type header option for requests/responses.

type: "application/jose+json" 
encoding: 8-bit

according to spec: https://tools.ietf.org/html/rfc7515#section-9.2.1