### PR TITLE
jws content type

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/ArtifactoryRequest.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/ArtifactoryRequest.java
@@ -30,6 +30,7 @@ public interface ArtifactoryRequest {
 
     enum ContentType {
         JSON("JSON"),
+        JWS("JWS"),
         TEXT("TEXT"),
         URLENC("URLENC"),
         ANY("ANY");

--- a/api/src/main/java/org/jfrog/artifactory/client/ArtifactoryRequest.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/ArtifactoryRequest.java
@@ -30,7 +30,8 @@ public interface ArtifactoryRequest {
 
     enum ContentType {
         JSON("JSON"),
-        JWS("JWS"),
+        JOSE("JOSE"),
+        JOSE_JSON("JOSE_JSON"),
         TEXT("TEXT"),
         URLENC("URLENC"),
         ANY("ANY");

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/ArtifactoryImpl.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/ArtifactoryImpl.java
@@ -137,7 +137,8 @@ public class ArtifactoryImpl implements Artifactory {
         switch (((ArtifactoryRequestImpl) request).getMethod().toString()) {
             case ("GET"):
                 String text = get(requestPath, String.class, null);
-                if (request.getResponseType() == ArtifactoryRequest.ContentType.JSON) {
+                if (request.getResponseType() == ArtifactoryRequest.ContentType.JSON
+                        || request.getResponseType() == ArtifactoryRequest.ContentType.JOSE_JSON) {
                     if (text.startsWith("[")) {
                         // create a valid json to parse for objectMapper
                         StringBuilder stringBuilder = new StringBuilder();
@@ -146,7 +147,7 @@ public class ArtifactoryImpl implements Artifactory {
                         });
                         return (T) hashMap.get("test");
                     }
-                    return (T) Util.parseObjectWithTypeReference(text,new TypeReference<HashMap<String, Object>>() {
+                    return (T) Util.parseObjectWithTypeReference(text, new TypeReference<HashMap<String, Object>>() {
                     });
                 }
                 return (T) text;
@@ -157,7 +158,8 @@ public class ArtifactoryImpl implements Artifactory {
                     queryPath = Util.getQueryPath("?", request.getQueryParams().entrySet());
                 }
                 String body = ((ArtifactoryRequestImpl) request).getBody();
-                if (request.getResponseType() == ArtifactoryRequest.ContentType.JSON) {
+                if (request.getResponseType() == ArtifactoryRequest.ContentType.JSON
+                        || request.getResponseType() == ArtifactoryRequest.ContentType.JOSE_JSON) {
                     return (T) post(requestPath + queryPath, contentType, body, request.getHeaders(), Map.class, null);
                 }
                 return (T) post(requestPath + queryPath, contentType, body, request.getHeaders(), String.class, null);

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/util/Util.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/util/Util.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.Consts;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.jfrog.artifactory.client.ArtifactoryRequest;
@@ -83,6 +84,10 @@ public class Util {
 
         if (contentType.equals(ArtifactoryRequest.ContentType.JSON)) {
             return ContentType.APPLICATION_JSON;
+        }
+
+        if (contentType.equals(ArtifactoryRequest.ContentType.JSON)) {
+            return ContentType.create("application/jose+json", Consts.ISO_8859_1);
         }
 
         if (contentType.equals(ArtifactoryRequest.ContentType.TEXT)) {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/util/Util.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/util/Util.java
@@ -87,11 +87,11 @@ public class Util {
         }
 
         if (contentType.equals(ArtifactoryRequest.ContentType.JOSE)) {
-            return ContentType.create("application/jose", Consts.UTF_8);
+            return ContentType.create("application/jose", Consts.ISO_8859_1);
         }
 
         if (contentType.equals(ArtifactoryRequest.ContentType.JOSE_JSON)) {
-            return ContentType.create("application/jose+json", Consts.ISO_8859_1);
+            return ContentType.create("application/jose+json", Consts.UTF_8);
         }
 
         if (contentType.equals(ArtifactoryRequest.ContentType.TEXT)) {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/util/Util.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/util/Util.java
@@ -86,7 +86,11 @@ public class Util {
             return ContentType.APPLICATION_JSON;
         }
 
-        if (contentType.equals(ArtifactoryRequest.ContentType.JSON)) {
+        if (contentType.equals(ArtifactoryRequest.ContentType.JOSE)) {
+            return ContentType.create("application/jose", Consts.UTF_8);
+        }
+
+        if (contentType.equals(ArtifactoryRequest.ContentType.JOSE_JSON)) {
             return ContentType.create("application/jose+json", Consts.ISO_8859_1);
         }
 


### PR DESCRIPTION
Added JWS content-type options for requests/responses.

type: "application/jose"
encoding: 8-bit

type: "application/jose+json"
encoding: UTF-8

according to spec: https://tools.ietf.org/html/rfc7515#section-9.2.1